### PR TITLE
Fix typo in start_stop.md

### DIFF
--- a/docs/user_guide/start_stop.md
+++ b/docs/user_guide/start_stop.md
@@ -24,4 +24,4 @@ Upon receiving SIGINT (ctrl + c), the server will exit immediately with no delay
 Upon receiving SIGTERM, the server will notify all its services to shutdown, wait for some preconfigured time and then exit. This behavior gives requests a grace period to finish.
 
 ### SIGQUIT: graceful upgrade
-Similar to SIGQUIT, but the server will also transfer all its listening sockets to a new Pingora server so that there is no downtime during the upgrade. See the [graceful upgrade](graceful.md) section for more details.
+Similar to SIGTERM, but the server will also transfer all its listening sockets to a new Pingora server so that there is no downtime during the upgrade. See the [graceful upgrade](graceful.md) section for more details.


### PR DESCRIPTION
fix typo. I assume it is supposed to say "Similar to SIGTERM" instead of "Similar to SIGQUIT"