### PR TITLE
Fix typo in quick start example

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -77,7 +77,7 @@ impl ProxyHttp for LB {
             .select(b"", 256) // hash doesn't matter for round robin
             .unwrap();
 
-        println!("upstream peer is: {:upstream?}");
+        println!("upstream peer is: {upstream:?}");
 
         // Set SNI to one.one.one.one
         let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));


### PR DESCRIPTION
Very tiny update on the output for the quick_start example