### PR TITLE
Slight performance boost in `pingora-limit::Estimator`

### DIFF
--- a/pingora-limits/src/estimator.rs
+++ b/pingora-limits/src/estimator.rs
@@ -77,11 +77,10 @@ impl Estimator {
 
     /// Reset all values inside this `Estimator`.
     pub fn reset(&self) {
-        for (slot, _) in self.estimator.iter() {
-            for counter in slot.iter() {
-                counter.store(0, Ordering::Relaxed);
-            }
-        }
+        self.estimator.iter().for_each(|(slot, _)| {
+            slot.iter()
+                .for_each(|counter| counter.store(0, Ordering::Relaxed))
+        });
     }
 }
 

--- a/pingora-limits/src/estimator.rs
+++ b/pingora-limits/src/estimator.rs
@@ -122,4 +122,17 @@ mod tests {
         assert_eq!(est.get("a"), 3);
         assert_eq!(est.get("b"), 3);
     }
+
+    #[test]
+    fn reset() {
+        let est = Estimator::new(8, 8);
+        est.incr("a", 1);
+        est.incr("a", 2);
+        est.incr("b", 1);
+        est.incr("b", 2);
+        est.decr("b", 1);
+        est.reset();
+        assert_eq!(est.get("a"), 0);
+        assert_eq!(est.get("b"), 0);
+    }
 }

--- a/pingora-limits/src/estimator.rs
+++ b/pingora-limits/src/estimator.rs
@@ -30,17 +30,12 @@ pub struct Estimator {
 impl Estimator {
     /// Create a new `Estimator` with the given amount of hashes and columns (slots).
     pub fn new(hashes: usize, slots: usize) -> Self {
-        let mut estimator = Vec::with_capacity(hashes);
-        for _ in 0..hashes {
-            let mut slot = Vec::with_capacity(slots);
-            for _ in 0..slots {
-                slot.push(AtomicIsize::new(0));
-            }
-            estimator.push((slot.into_boxed_slice(), RandomState::new()));
-        }
-
-        Estimator {
-            estimator: estimator.into_boxed_slice(),
+        Self {
+            estimator: (0..hashes)
+                .map(|_| (0..slots).map(|_| AtomicIsize::new(0)).collect::<Vec<_>>())
+                .map(|slot| (slot.into_boxed_slice(), RandomState::new()))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
         }
     }
 


### PR DESCRIPTION
I was tinkering with the code, to my surprise I made `Estimator` run faster just by using iterators instead of for-loops

The overall diff is about 60% faster on single thread

```Pingora Estimator single thread 2.334566806s total, 23ns avg per operation``` 

vs 

```Pingora Estimator single thread 868.937015ms total, 8ns avg per operation```

There is 2ns gain per thread, from 25ns -> 23ns (8%).


I have attached the complete bench diff for my machine: https://www.diffchecker.com/9EnuDEot/

I may be missing/ignoring something here, cause this is too good to be true.

Though this is a [documented and tested](https://doc.rust-lang.org/book/ch13-04-performance.html) behavior.

I have also added a test for `reset` method, which might be redundant.