### PR TITLE
docs(pingora-proxy): fix typos in the nginx.conf

### DIFF
--- a/pingora-proxy/tests/utils/conf/origin/conf/nginx.conf
+++ b/pingora-proxy/tests/utils/conf/origin/conf/nginx.conf
@@ -253,7 +253,7 @@ http {
             return 200;
         }
 
-        # 1. A origin load balancer that rejects reused connetions.
+        # 1. A origin load balancer that rejects reused connections.
         # this is to simulate the common problem when customers LB drops
         # connection silently after being keepalived for awhile
         # 2. A middlebox might drop the connection if the origin takes too long


### PR DESCRIPTION
fix the typos in the nginx.conf file in the pingora-proxy modules.