### PR TITLE
Ensure consistent usage of docs.rs links in rustdoc comments

### DIFF
--- a/pingora-boringssl/src/lib.rs
+++ b/pingora-boringssl/src/lib.rs
@@ -15,7 +15,7 @@
 //! The BoringSSL API compatibility layer.
 //!
 //! This crate aims at making [boring] APIs exchangeable with [openssl-rs](https://docs.rs/openssl/latest/openssl/).
-//! In other words, this crate and `pingora-openssl` expose identical rust APIs.
+//! In other words, this crate and [`pingora-openssl`](https://docs.rs/pingora-openssl) expose identical rust APIs.
 
 #![warn(clippy::all)]
 

--- a/pingora-core/src/lib.rs
+++ b/pingora-core/src/lib.rs
@@ -34,7 +34,7 @@
 //! # Usage
 //! This crate provides low level service and protocol implementation and abstraction.
 //!
-//! If looking to build a (reverse) proxy, see `pingora-proxy` crate.
+//! If looking to build a (reverse) proxy, see [`pingora-proxy`](https://docs.rs/pingora-proxy) crate.
 //!
 //! # Optional features
 //! `boringssl`: Switch the internal TLS library from OpenSSL to BoringSSL.

--- a/pingora-ketama/src/lib.rs
+++ b/pingora-ketama/src/lib.rs
@@ -54,7 +54,7 @@
 //! We've provided a health-aware example in
 //! `pingora-ketama/examples/health_aware_selector.rs`.
 //!
-//! For a carefully crafted real-world example, see the pingora-load-balancer
+//! For a carefully crafted real-world example, see the [`pingora-load-balancing`](https://docs.rs/pingora-load-balancing)
 //! crate.
 
 use std::cmp::Ordering;

--- a/pingora-openssl/src/ext.rs
+++ b/pingora-openssl/src/ext.rs
@@ -165,7 +165,7 @@ pub fn clear_error_stack() {
 
 /// Create a new [Ssl] from &[SslAcceptor]
 ///
-/// this function is to unify the interface between this crate and `pingora-boringssl`
+/// this function is to unify the interface between this crate and [`pingora-boringssl`](https://docs.rs/pingora-boringssl)
 pub fn ssl_from_acceptor(acceptor: &SslAcceptor) -> Result<Ssl, ErrorStack> {
     Ssl::new(acceptor.context())
 }

--- a/pingora-openssl/src/lib.rs
+++ b/pingora-openssl/src/lib.rs
@@ -15,7 +15,7 @@
 //! The OpenSSL API compatibility layer.
 //!
 //! This crate aims at making [openssl] APIs interchangeable with [boring](https://docs.rs/boring/latest/boring/).
-//! In other words, this crate and `pingora-boringssl` expose identical rust APIs.
+//! In other words, this crate and [`pingora-boringssl`](https://docs.rs/pingora-boringssl) expose identical rust APIs.
 
 #![warn(clippy::all)]
 


### PR DESCRIPTION
In some but not all of the documentation there we `docs.rs` links to the various other crates. This change adds these `docs.rs` links to all mentions of other crates in rustdoc comments.
It also fixes that the [pingora-ketama](https://github.com/cloudflare/pingora/compare/main...zegevlier:pingora:main#diff-0daaad205331982fce6ea251461c356601d231bc7a4c514a8892706174401e7d) documentation referred to a non-existent crate.