### PR TITLE
Fix #30 build fails with boringssl feature

### DIFF
--- a/pingora-core/src/protocols/ssl/client.rs
+++ b/pingora-core/src/protocols/ssl/client.rs
@@ -17,11 +17,7 @@
 use super::SslStream;
 use crate::protocols::raw_connect::ProxyDigest;
 use crate::protocols::{GetProxyDigest, GetTimingDigest, TimingDigest, IO};
-use crate::tls::{
-    ssl,
-    ssl::ConnectConfiguration,
-    ssl_sys::{X509_V_ERR_INVALID_CALL, X509_V_OK},
-};
+use crate::tls::{ssl, ssl::ConnectConfiguration, ssl_sys::X509_V_ERR_INVALID_CALL};
 
 use pingora_error::{Error, ErrorType::*, OrErr, Result};
 use std::sync::Arc;
@@ -44,27 +40,28 @@ pub async fn handshake<S: IO>(
             let context = format!("TLS connect() failed: {e}, SNI: {domain}");
             match e.code() {
                 ssl::ErrorCode::SSL => {
+                    // Unify the return type of `verify_result` for openssl
                     #[cfg(not(feature = "boringssl"))]
-                    match stream.ssl().verify_result().as_raw() {
+                    fn verify_result<S>(stream: SslStream<S>) -> Result<(), i32> {
+                        match stream.ssl().verify_result().as_raw() {
+                            crate::tls::ssl_sys::X509_V_OK => Ok(()),
+                            e => Err(e),
+                        }
+                    }
+
+                    // Unify the return type of `verify_result` for boringssl
+                    #[cfg(feature = "boringssl")]
+                    fn verify_result<S>(stream: SslStream<S>) -> Result<(), i32> {
+                        stream.ssl().verify_result().map_err(|e| e.as_raw())
+                    }
+
+                    match verify_result(stream) {
+                        Ok(()) => Error::e_explain(TLSHandshakeFailure, context),
                         // X509_V_ERR_INVALID_CALL in case verify result was never set
-                        X509_V_OK | X509_V_ERR_INVALID_CALL => {
+                        Err(X509_V_ERR_INVALID_CALL) => {
                             Error::e_explain(TLSHandshakeFailure, context)
                         }
                         _ => Error::e_explain(InvalidCert, context),
-                    }
-
-                    #[cfg(feature = "boringssl")]
-                    match stream.ssl().verify_result() {
-                        Ok(()) => Error::e_explain(TLSHandshakeFailure, context),
-                        Err(e) => {
-                            match e.as_raw() {
-                                // X509_V_ERR_INVALID_CALL in case verify result was never set
-                                X509_V_OK | X509_V_ERR_INVALID_CALL => {
-                                    Error::e_explain(TLSHandshakeFailure, context)
-                                }
-                                _ => Error::e_explain(InvalidCert, context),
-                            }
-                        }
                     }
                 }
                 /* likely network error, but still mark as TLS error */


### PR DESCRIPTION
In this commit [cloudflare/boring@84a80c1](https://github.com/cloudflare/boring/commit/84a80c191616c1aa2f21513f67b7c53e75b9af39) , the `X509VerifyResult` from [cloudflare/boring](https://github.com/cloudflare/boring) was modified to `Result<(), X509VerifyError>` . This change introduces an incompatibility with X509VerifyResult.

Changes in this Pull Request:

This pull request addresses the incompatibility by providing feature-specific code blocks:

- `#[cfg(not(feature = "boringssl"))]` This block preserves existing behavior for openssl-based `stream.ssl().verify_result()`.
- `#[cfg(feature = "boringssl")]` Handles the updated boringssl `Result<(), X509VerifyError>` result type from `stream.ssl().verify_result()`.