### PR TITLE
feat: expose request length in Session

### DIFF
--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -330,4 +330,12 @@ impl Session {
             Self::H2(s) => s.body_bytes_sent(),
         }
     }
+
+    /// How many request body already read, including request headers
+    pub fn request_length(&self) -> usize {
+        match self {
+            Self::H1(s) => s.request_length(),
+            Self::H2(s) => s.request_length(),
+        }
+    }
 }

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -609,6 +609,11 @@ impl HttpSession {
         Ok(res)
     }
 
+    /// Return how many request header and body bytes that have been read
+    pub fn request_length(&self) -> usize {
+        self.buf.len()
+    }
+
     /// Return how many (application, not wire) body bytes that have been written
     pub fn body_bytes_sent(&self) -> usize {
         self.body_bytes_sent

--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -401,6 +401,11 @@ impl HttpSession {
         }
     }
 
+    /// Return how many request header and body bytes that have been read
+    pub fn request_length(&self) -> usize {
+        self.body_read
+    }
+
     /// How many response body bytes sent to the client
     pub fn body_bytes_sent(&self) -> usize {
         self.body_sent


### PR DESCRIPTION
for statistic inbound traffic, like `$request_length` in nginx