### PR TITLE
fix typos by tool `typos`

### DIFF
--- a/docs/user_guide/conf.md
+++ b/docs/user_guide/conf.md
@@ -27,7 +27,7 @@ group: webusers
 | client_bind_to_ipv6 | source IPv6 addresses to bind to when connecting to server| list of string |
 | ca_file | The path to the root CA file | string |
 | work_stealing | Enable work stealing runtime (default true). See Pingora runtime (WIP) section for more info | bool |
-| upstream_keepalive_pool_size | The number of total connections to keep in the connetion pool | number |
+| upstream_keepalive_pool_size | The number of total connections to keep in the connection pool | number |
 
 ## Extension
 Any unknown settings will be ignored. This allows extending the conf file to add and pass user defined settings. See User defined configuration section.

--- a/docs/user_guide/error_log.md
+++ b/docs/user_guide/error_log.md
@@ -6,7 +6,7 @@ Pingora libraries are built to expect issues like disconnects, timeouts and inva
 Pingora adopts the idea behind [log](https://docs.rs/log/latest/log/). There are five log levels:
 * `error`: This level should be used when the error stops the request from being handled correctly. For example when the server we try to connect to is offline.
 * `warning`: This level should be used when an error occurs but the system recovers from it. For example when the primary DNS timed out but the system is able to query the secondary DNS.
-* `info`: Pingora logs when the server is starting up or shuting down.
+* `info`: Pingora logs when the server is starting up or shutting down.
 * `debug`: Internal details. This log level is not compiled in `release` builds.
 * `trace`: Fine-grained internal details. This log level is not compiled in `release` builds.
 

--- a/docs/user_guide/peer.md
+++ b/docs/user_guide/peer.md
@@ -22,7 +22,7 @@ A `PeerOptions` defines how to connect to the upstream.
 |connection_timeout: `Option<Duration>`| How long to wait before giving up *establishing* a TCP connection |
 |total_connection_timeout: `Option<Duration>`| How long to wait before giving up *establishing* a connection including TLS handshake time |
 |read_timeout: `Option<Duration>`| How long to wait before each individual `read()` from upstream. The timer is reset after each `read()` |
-|idle_timeout: `Option<Duration>`| How long to wait before closing a idle connection waiting for connetion reuse |
+|idle_timeout: `Option<Duration>`| How long to wait before closing a idle connection waiting for connection reuse |
 |write_timeout: `Option<Duration>`| How long to wait before a `write()` to upstream finishes |
 |verify_cert: `bool`| Whether to check if upstream' server cert is valid and validated |
 |verify_hostname: `bool`| Whether to check if upstream server cert's CN matches the SNI |

--- a/docs/user_guide/start_stop.md
+++ b/docs/user_guide/start_stop.md
@@ -1,4 +1,4 @@
-# Starting and stoping Pingora server
+# Starting and stopping Pingora server
 
 A pingora server is a regular unprivileged multithreaded process.
 
@@ -11,7 +11,7 @@ A Pingora server by default takes the following command-line arguments:
 | ------------- |-------------| ----|
 | -d, --daemon | Daemonize the server | false |
 | -t, --test | Test the server conf and then exit (WIP) | false |
-| -c, --conf | The path to the configuarion file | empty string |
+| -c, --conf | The path to the configuration file | empty string |
 | -u, --upgrade | This server should gracefully upgrade a running server | false |
 
 ## Stop

--- a/pingora-cache/src/eviction/lru.rs
+++ b/pingora-cache/src/eviction/lru.rs
@@ -32,7 +32,7 @@ use std::time::SystemTime;
 ///
 /// - Space optimized in-memory LRU (see [pingora_lru]).
 /// - Instead of a single giant LRU, this struct shards the assets into `N` independent LRUs.
-/// This allows [EvictionManager::save()] not to lock the entire cache mananger while performing
+/// This allows [EvictionManager::save()] not to lock the entire cache manager while performing
 /// serialization.
 pub struct Manager<const N: usize>(Lru<CompactCacheKey, N>);
 

--- a/pingora-cache/src/eviction/mod.rs
+++ b/pingora-cache/src/eviction/mod.rs
@@ -29,9 +29,9 @@ pub mod simple_lru;
 /// be handled the implementations internally.
 #[async_trait]
 pub trait EvictionManager {
-    /// Total size of the cache in bytes tracked by this eviction mananger
+    /// Total size of the cache in bytes tracked by this eviction manager
     fn total_size(&self) -> usize;
-    /// Number of assets tracked by this eviction mananger
+    /// Number of assets tracked by this eviction manager
     fn total_items(&self) -> usize;
     /// Number of bytes that are already evicted
     ///
@@ -76,7 +76,7 @@ pub trait EvictionManager {
     /// method shouldn't change the popularity of the asset being peeked.
     fn peek(&self, item: &CompactCacheKey) -> bool;
 
-    /// Serialize to save the state of this eviction mananger to disk
+    /// Serialize to save the state of this eviction manager to disk
     ///
     /// This function is for preserving the eviction manager's state across server restarts.
     ///

--- a/pingora-cache/src/filters.rs
+++ b/pingora-cache/src/filters.rs
@@ -187,7 +187,7 @@ pub mod upstream {
         // remove downstream range header as we'd like to cache the entire response (this might change in the future)
         req.remove_header(&header::RANGE);
 
-        // we have a persumably staled response already, add precondition headers for revalidation
+        // we have a presumably staled response already, add precondition headers for revalidation
         if let Some(m) = meta {
             // rfc7232: "SHOULD send both validators in cache validation" but
             // there have been weird cases that an origin has matching etag but not Last-Modified

--- a/pingora-cache/src/lib.rs
+++ b/pingora-cache/src/lib.rs
@@ -340,7 +340,7 @@ impl HttpCache {
     /// Enable the cache
     ///
     /// - `storage`: the cache storage backend that implements [storage::Storage]
-    /// - `eviction`: optionally the eviction mananger, without it, nothing will be evicted from the storage
+    /// - `eviction`: optionally the eviction manager, without it, nothing will be evicted from the storage
     /// - `predictor`: optionally a cache predictor. The cache predictor predicts whether something is likely
     /// to be cacheable or not. This is useful because the proxy can apply different types of optimization to
     /// cacheable and uncacheable requests.

--- a/pingora-cache/src/memory.rs
+++ b/pingora-cache/src/memory.rs
@@ -151,7 +151,7 @@ impl PartialHit {
             };
             assert!(bytes_end >= self.bytes_read);
 
-            // more data avaliable to read
+            // more data available to read
             if bytes_end > self.bytes_read {
                 let new_bytes =
                     Bytes::copy_from_slice(&self.body.read()[self.bytes_read..bytes_end]);

--- a/pingora-cache/src/meta.rs
+++ b/pingora-cache/src/meta.rs
@@ -316,7 +316,7 @@ pub(crate) struct CacheMetaInner {
     pub(crate) internal: InternalMeta,
     pub(crate) header: ResponseHeader,
     /// An opaque type map to hold extra information for communication between cache backends
-    /// and users. This field is **not** garanteed be persistently stored in the cache backend.
+    /// and users. This field is **not** guaranteed be persistently stored in the cache backend.
     pub extensions: Extensions,
 }
 

--- a/pingora-core/src/connectors/tls.rs
+++ b/pingora-core/src/connectors/tls.rs
@@ -217,7 +217,7 @@ where
     if peer.sni().is_empty() {
         ssl_conf.set_use_server_name_indication(false);
         /* NOTE: technically we can still verify who signs the cert but turn it off to be
-        consistant with nginx's behavior */
+        consistent with nginx's behavior */
         ssl_conf.set_verify(SslVerifyMode::NONE);
     } else if peer.verify_cert() {
         if peer.verify_hostname() {

--- a/pingora-core/src/protocols/http/compression/mod.rs
+++ b/pingora-core/src/protocols/http/compression/mod.rs
@@ -257,7 +257,7 @@ enum Algorithm {
     Zstd,
     // TODO: Identify,
     // TODO: Deflate
-    Other, // anyting unknown
+    Other, // anything unknown
 }
 
 impl Algorithm {
@@ -322,7 +322,7 @@ enum Action {
     Decompress(Algorithm),
 }
 
-// parse Accpet-Encoding header and put it to the list
+// parse Accept-Encoding header and put it to the list
 fn parse_accept_encoding(accept_encoding: Option<&http::HeaderValue>, list: &mut Vec<Algorithm>) {
     // https://www.rfc-editor.org/rfc/rfc9110#name-accept-encoding
     if let Some(ac) = accept_encoding {
@@ -339,7 +339,7 @@ fn parse_accept_encoding(accept_encoding: Option<&http::HeaderValue>, list: &mut
                         if let Some(s) = i.bare_item.as_token() {
                             // TODO: support q value
                             let algorithm = Algorithm::from(s);
-                            // ignore algorithms that we don't understand ingore
+                            // ignore algorithms that we don't understand ignore
                             if algorithm != Algorithm::Other {
                                 list.push(Algorithm::from(s));
                             }
@@ -400,7 +400,7 @@ fn decide_action(resp: &ResponseHeader, accept_encoding: &[Algorithm]) -> Action
             Some(Algorithm::Other)
         }
     } else {
-        // no Accpet-encoding
+        // no Accept-encoding
         None
     };
 

--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -231,7 +231,7 @@ impl Session {
     /// Send error response to client
     pub async fn respond_error(&mut self, error: u16) {
         let resp = match error {
-            /* commmon error responses are pre-generated */
+            /* common error responses are pre-generated */
             502 => error_resp::HTTP_502_RESPONSE.clone(),
             400 => error_resp::HTTP_400_RESPONSE.clone(),
             _ => error_resp::gen_error_response(error),

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -772,7 +772,7 @@ impl HttpSession {
     /// It has no response body.
     pub async fn respond_error(&mut self, error_status_code: u16) {
         let (resp, resp_tmp) = match error_status_code {
-            /* commmon error responses are pre-generated */
+            /* common error responses are pre-generated */
             502 => (Some(&*error_resp::HTTP_502_RESPONSE), None),
             400 => (Some(&*error_resp::HTTP_400_RESPONSE), None),
             _ => (

--- a/pingora-core/src/protocols/l4/ext.rs
+++ b/pingora-core/src/protocols/l4/ext.rs
@@ -212,7 +212,7 @@ pub fn get_tcp_info(_fd: RawFd) -> io::Result<TCP_INFO> {
 }
 
 /*
- * this extention is needed until the following are addressed
+ * this extension is needed until the following are addressed
  * https://github.com/tokio-rs/tokio/issues/1543
  * https://github.com/tokio-rs/mio/issues/1257
  * https://github.com/tokio-rs/mio/issues/1211

--- a/pingora-core/tests/nginx_proxy.conf
+++ b/pingora-core/tests/nginx_proxy.conf
@@ -32,7 +32,7 @@ http {
     keepalive_timeout  30;
     keepalive_requests 99999;
 
-    upstream plantext {
+    upstream plaintext {
         server 127.0.0.1:8000;
         keepalive 128;
         keepalive_requests 99999;
@@ -53,7 +53,7 @@ http {
 
         location / {
             keepalive_timeout 30;
-            proxy_pass http://plantext;
+            proxy_pass http://plaintext;
             proxy_http_version 1.1;
             proxy_set_header Connection "Keep-Alive";
         }

--- a/pingora-proxy/src/proxy_cache.rs
+++ b/pingora-proxy/src/proxy_cache.rs
@@ -220,7 +220,7 @@ impl<SV> HttpProxy<SV> {
                 }
                 Err(e) => {
                     // Allow cache miss to fill cache even if cache lookup errors
-                    // this is mostly to suppport backward incompatible metadata update
+                    // this is mostly to support backward incompatible metadata update
                     // TODO: check error types
                     // session.cache.disable();
                     self.inner.cache_miss(session, ctx);
@@ -280,7 +280,7 @@ impl<SV> HttpProxy<SV> {
             Err(e) => {
                 // TODO: more logging and error handling
                 session.as_mut().respond_error(500).await;
-                // we have not write anything dirty to downstream, it is still reuseable
+                // we have not write anything dirty to downstream, it is still reusable
                 return (true, Some(e));
             }
         }
@@ -716,7 +716,7 @@ pub(crate) mod range_filter {
     use http::header::*;
     use std::ops::Range;
 
-    // parse bytes into usize, ignores specifc error
+    // parse bytes into usize, ignores specific error
     fn parse_number(input: &[u8]) -> Option<usize> {
         str::from_utf8(input).ok()?.parse().ok()
     }

--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -20,7 +20,7 @@ use pingora_cache::{
 /// The interface to control the HTTP proxy
 ///
 /// The methods in [ProxyHttp] are filters/callbacks which will be performed on all requests at their
-/// paticular stage (if applicable).
+/// particular stage (if applicable).
 ///
 /// If any of the filters returns [Result::Err], the request will fail and the error will be logged.
 #[cfg_attr(not(doc_async_trait), async_trait)]
@@ -264,7 +264,7 @@ pub trait ProxyHttp {
     ///
     /// If the error can be retried, [Self::upstream_peer()] will be called again so that the user
     /// can decide whether to send the request to the same upstream or another upstream that is possibly
-    /// avaliable.
+    /// available.
     fn fail_to_connect(
         &self,
         _session: &mut Session,

--- a/pingora-proxy/tests/utils/conf/origin/conf/nginx.conf
+++ b/pingora-proxy/tests/utils/conf/origin/conf/nginx.conf
@@ -283,7 +283,7 @@ http {
                 ngx.print(string.rep("A", 64))
                 ngx.print(string.rep("A", 64))
                 ngx.print(string.rep("A", 64))
-                -- without ngx.req.read_body(), the body will return wihtout waiting for req body
+                -- without ngx.req.read_body(), the body will return without waiting for req body
             }
         }
 

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -389,7 +389,7 @@ impl Server {
     }
 }
 
-// FIXME: this still allows multiple servers to spawn across intergration tests
+// FIXME: this still allows multiple servers to spawn across integration tests
 pub static TEST_SERVER: Lazy<Server> = Lazy::new(Server::start);
 use super::mock_origin::MOCK_ORIGIN;
 

--- a/pingora-timeout/src/fast_timeout.rs
+++ b/pingora-timeout/src/fast_timeout.rs
@@ -20,7 +20,7 @@
 //! - Timeout timers are rounded to the next 10ms tick and timers are shared across all timeouts with the same deadline.
 //!
 //! In order for this to work, a standalone thread is created to arm the timers, which has its
-//! overheads. As a general rule, the benefits of this doesn't outweight the overhead unless
+//! overheads. As a general rule, the benefits of this doesn't outweigh the overhead unless
 //! there are more than about 100/s timeout() calls in the system. Use regular tokio timeout or
 //! [super::tokio_timeout] in the low usage case.
 


### PR DESCRIPTION
Seems many PRs about fixing typos, I'd like to share the tool [typos](https://github.com/crate-ci/typos) which can  show the typos and fix them easily.

Run `typos -w` will fix all typos as below. This PR is just an example, wish will help.

`typos` also can be used by Github action.