### PR TITLE
Update proxy_h2.rs

### DIFF
--- a/pingora-proxy/src/proxy_h2.rs
+++ b/pingora-proxy/src/proxy_h2.rs
@@ -102,6 +102,10 @@ impl<SV> HttpProxy<SV> {
             .inner
             .upstream_request_filter(session, &mut req, ctx)
             .await
+            .map_err(|e| {
+                error!("Error in upstream_request_filter: {}", e);
+                e
+            }) 
         {
             Ok(_) => { /* continue */ }
             Err(e) => {


### PR DESCRIPTION
添加一个闭包，记录错误并返回一个带有详细错误信息的 Box<Error>，在调用 upstream_request_filter 后使用 map_err 处理错误，提高代码的可读性。