### PR TITLE
Fix quick start guide println

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -77,7 +77,7 @@ impl ProxyHttp for LB {
             .select(b"", 256) // hash doesn't matter for round robin
             .unwrap();
 
-        println!("upstream peer is: {:upstream?}");
+        println!("upstream peer is: {:?}", upstream);
 
         // Set SNI to one.one.one.one
         let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));


### PR DESCRIPTION
Otherwise you get this error:

```
error: invalid format string: expected `'}'`, found `'?'`
  --> src/main.rs:21:47
   |
21 |         println!("upstream peer is: {:upstream?}");
   |                                     -         ^ expected `'}'` in format string
   |                                     |
   |                                     because of this opening brace
   |
   = note: if you intended to print `{`, you can escape it using `{{`

error: could not compile `pnginx` (bin "pnginx") due to 1 previous error
```