### PR TITLE
Do not sleep after calling Runtime::shutdown_timeout

### DIFF
--- a/pingora-core/src/server/mod.rs
+++ b/pingora-core/src/server/mod.rs
@@ -316,10 +316,7 @@ impl Server {
             .into_iter()
             .map(|rt| {
                 info!("Waiting for runtimes to exit!");
-                thread::spawn(move || {
-                    rt.shutdown_timeout(shutdown_timeout);
-                    thread::sleep(shutdown_timeout)
-                })
+                thread::spawn(move || rt.shutdown_timeout(shutdown_timeout))
             })
             .collect();
         for shutdown in shutdowns {


### PR DESCRIPTION
Since we wait for shutdowns at https://github.com/hnakamur/pingora/blob/45791f63455267e41191e03d8895704fe59f7b98/pingora-core/src/server/mod.rs#L325-L329, sleep is redundant.

I tested this pull request manually with modified run_service below:
```
    fn run_service(
        mut service: Box<dyn Service>,
        fds: Option<ListenFds>,
        shutdown: ShutdownWatch,
        threads: usize,
        work_stealing: bool,
    ) -> Runtime
// NOTE: we need to keep the runtime outside async since
        // otherwise the runtime will be dropped.
    {
        let service_runtime = Server::create_runtime(service.name(), threads, work_stealing);
        service_runtime.get_handle().spawn(async move {
            service.start_service(fds, shutdown).await;
            info!("service exited#1, sleeping 3 seconds..."); // Added
            std::thread::sleep(std::time::Duration::from_secs(3)); // Added
            info!("service exited.")
        });
        service_runtime
    }
```

And got the following log output:
```
[2024-03-03T00:41:51Z INFO  pingora_core::server] service exited#1, sleeping 3 seconds...
[2024-03-03T00:41:54Z INFO  pingora_core::server] service exited.
[2024-03-03T00:41:54Z INFO  pingora_core::server] All runtimes exited, exiting now
```
