### PR TITLE
Use SeqCst consistently to operate on the clock_watchdog variable

### DIFF
--- a/pingora-timeout/src/timer.rs
+++ b/pingora-timeout/src/timer.rs
@@ -132,7 +132,7 @@ impl TimerManager {
             std::thread::sleep(RESOLUTION_DURATION);
             let now = Instant::now() - self.zero;
             self.clock_watchdog
-                .store(now.as_secs() as i64, Ordering::Relaxed);
+                .store(now.as_secs() as i64, Ordering::SeqCst);
             if self.is_paused_for_fork() {
                 // just stop acquiring the locks, waiting for fork to happen
                 continue;


### PR DESCRIPTION
If operations on clock_watchdog all use SeqCst, then use `SeqCst` consistently.