### PR TITLE
fix `cargo run --example server`, missing cert

### DIFF
--- a/pingora/tests/keys
+++ b/pingora/tests/keys
@@ -1,0 +1,1 @@
+../../pingora-core/tests/keys


### PR DESCRIPTION
Running `cargo run --example server` throws an error caused by missing the `pingora/test/keys` folder.

This PR copies the cert from the `pandora-core` folder, so the example runs out of the box.

Hopefully, this will save a few minutes for the next person trying to run `cargo run --example server` right after cloning.