### PR TITLE
Only compile pingora-openssl and its deps when openssl is enabled.

### DIFF
--- a/pingora-cache/Cargo.toml
+++ b/pingora-cache/Cargo.toml
@@ -17,7 +17,7 @@ name = "pingora_cache"
 path = "src/lib.rs"
 
 [dependencies]
-pingora-core = { version = "0.1.0", path = "../pingora-core" }
+pingora-core = { version = "0.1.0", path = "../pingora-core", default-features = false }
 pingora-error = { version = "0.1.0", path = "../pingora-error" }
 pingora-header-serde = { version = "0.1.0", path = "../pingora-header-serde" }
 pingora-http = { version = "0.1.0", path = "../pingora-http" }
@@ -62,3 +62,8 @@ harness = false
 [[bench]]
 name = "lru_serde"
 harness = false
+
+[features]
+default = ["openssl"]
+openssl = ["pingora-core/openssl"]
+boringssl = ["pingora-core/boringssl"]

--- a/pingora-load-balancing/Cargo.toml
+++ b/pingora-load-balancing/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 async-trait = { workspace = true }
 pingora-http = { version = "0.1.0", path = "../pingora-http" }
 pingora-error = { version = "0.1.0", path = "../pingora-error" }
-pingora-core = { version = "0.1.0", path = "../pingora-core" }
+pingora-core = { version = "0.1.0", path = "../pingora-core", default-features = false }
 pingora-ketama = { version = "0.1.0", path = "../pingora-ketama" }
 pingora-runtime = { version = "0.1.0", path = "../pingora-runtime" }
 arc-swap = "1"
@@ -31,3 +31,8 @@ futures = "0"
 log = { workspace = true }
 
 [dev-dependencies]
+
+[features]
+default = ["openssl"]
+openssl = ["pingora-core/openssl"]
+boringssl = ["pingora-core/boringssl"]

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -19,9 +19,9 @@ path = "src/lib.rs"
 
 [dependencies]
 pingora-error = { version = "0.1.0", path = "../pingora-error" }
-pingora-core = { version = "0.1.0", path = "../pingora-core" }
+pingora-core = { version = "0.1.0", path = "../pingora-core", default-features = false }
 pingora-timeout = { version = "0.1.0", path = "../pingora-timeout" }
-pingora-cache = { version = "0.1.0", path = "../pingora-cache" }
+pingora-cache = { version = "0.1.0", path = "../pingora-cache", default-features = false }
 tokio = { workspace = true, features = ["macros", "net"] }
 pingora-http = { version = "0.1.0", path = "../pingora-http" }
 http = { workspace = true }
@@ -47,3 +47,8 @@ tokio-tungstenite = "0.20.1"
 pingora-load-balancing = { version = "0.1.0", path = "../pingora-load-balancing" }
 prometheus = "0"
 futures-util = "0.3"
+
+[features]
+default = ["openssl"]
+openssl = ["pingora-core/openssl", "pingora-cache/openssl"]
+boringssl = ["pingora-core/boringssl", "pingora-cache/boringssl"]

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -18,12 +18,12 @@ name = "pingora"
 path = "src/lib.rs"
 
 [dependencies]
-pingora-core = { version = "0.1.0", path = "../pingora-core" }
+pingora-core = { version = "0.1.0", path = "../pingora-core", default-features = false }
 pingora-http = { version = "0.1.0", path = "../pingora-http" }
 pingora-timeout = { version = "0.1.0", path = "../pingora-timeout" }
-pingora-load-balancing = { version = "0.1.0", path = "../pingora-load-balancing", optional = true }
-pingora-proxy = { version = "0.1.0", path = "../pingora-proxy", optional = true }
-pingora-cache = { version = "0.1.0", path = "../pingora-cache", optional = true }
+pingora-load-balancing = { version = "0.1.0", path = "../pingora-load-balancing", optional = true, default-features = false }
+pingora-proxy = { version = "0.1.0", path = "../pingora-proxy", optional = true, default-features = false }
+pingora-cache = { version = "0.1.0", path = "../pingora-cache", optional = true, default-features = false }
 
 [dev-dependencies]
 structopt = "0.3"
@@ -44,8 +44,18 @@ regex = "1"
 
 [features]
 default = ["openssl"]
-openssl = ["pingora-core/openssl"]
-boringssl = ["pingora-core/boringssl"]
+openssl = [
+    "pingora-core/openssl",
+    "pingora-proxy?/openssl",
+    "pingora-cache?/openssl",
+    "pingora-load-balancing?/openssl",
+]
+boringssl = [
+    "pingora-core/boringssl",
+    "pingora-proxy?/boringssl",
+    "pingora-cache?/boringssl",
+    "pingora-load-balancing?/boringssl",
+]
 proxy = ["pingora-proxy"]
 lb = ["pingora-load-balancing", "proxy"]
 cache = ["pingora-cache"]


### PR DESCRIPTION
Enabling `boringssl` should only compile `pingora-boringssl` but `pingora-openssl` still gets compiled. This is not what I expected.

This PR fixes this issue by updating the `Cargo.toml` files for several crates to set `default-features` to `false`. This ensures that the `openssl` feature of `pingora-core` and its dependency `pingora-openssl` are only depended on when the `openssl` feature is enabled.