### PR TITLE
fix: deprecated of from_timestamp_opt

### DIFF
--- a/pingora-core/src/protocols/http/date.rs
+++ b/pingora-core/src/protocols/http/date.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use http::header::HeaderValue;
 use std::cell::RefCell;
 use std::time::{Duration, SystemTime};
 
 fn to_date_string(epoch_sec: i64) -> String {
-    let dt = NaiveDateTime::from_timestamp_opt(epoch_sec, 0).unwrap();
+    let dt = DateTime::from_timestamp(epoch_sec, 0).unwrap();
     dt.format("%a, %d %b %Y %H:%M:%S GMT").to_string()
 }
 


### PR DESCRIPTION
`NaiveDateTime::from_timestamp_opt` had been tagged `deprecated` since chrono 0.4.23, it suggests using `DateTime::from_timestamp` instead of.