### PR TITLE
Fix voldemort types in public interface

### DIFF
--- a/pingora-core/src/server/mod.rs
+++ b/pingora-core/src/server/mod.rs
@@ -30,7 +30,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::services::Service;
 use configuration::{Opt, ServerConf};
-use transfer_fd::Fds;
+pub use transfer_fd::Fds;
 
 use pingora_error::{Error, ErrorType, Result};
 
@@ -49,7 +49,7 @@ enum ShutdownType {
 /// The receiver for server's shutdown event. The value will turn to true once the server starts
 /// to shutdown
 pub type ShutdownWatch = watch::Receiver<bool>;
-pub(crate) type ListenFds = Arc<Mutex<Fds>>;
+pub type ListenFds = Arc<Mutex<Fds>>;
 
 /// The server object
 ///


### PR DESCRIPTION
The `Fds` struct used in `ListenFds` in the `pingora::services::Service` trait is not nameable. See https://rust-lang.github.io/rfcs/2145-type-privacy.html#lint-3-voldemort-types-its-reachable-but-i-cant-name-it

This change makes both `ListenFds` and `Fds` public.

As a side-effect all of the methods on `Fds` are now public as well but are not documented.

Fixes: https://github.com/cloudflare/pingora/issues/145