### PR TITLE
Expose currently pub(crate) configuration options, provide new Server constructor

### DIFF
--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -36,7 +36,8 @@ use structopt::StructOpt;
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ServerConf {
-    version: usize,
+    /// Version
+    pub version: usize,
     /// Whether to run this process in the background.
     pub daemon: bool,
     /// When configured, error log will be written to the given file. Otherwise StdErr will be used.

--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -61,11 +61,11 @@ pub struct ServerConf {
     /// defined by the SSL library will be used.
     pub ca_file: Option<String>,
     // These options don't belong here as they are specific to certain services
-    pub(crate) client_bind_to_ipv4: Vec<String>,
-    pub(crate) client_bind_to_ipv6: Vec<String>,
-    pub(crate) upstream_keepalive_pool_size: usize,
-    pub(crate) upstream_connect_offload_threadpools: Option<usize>,
-    pub(crate) upstream_connect_offload_thread_per_pool: Option<usize>,
+    pub client_bind_to_ipv4: Vec<String>,
+    pub client_bind_to_ipv6: Vec<String>,
+    pub upstream_keepalive_pool_size: usize,
+    pub upstream_connect_offload_threadpools: Option<usize>,
+    pub upstream_connect_offload_thread_per_pool: Option<usize>,
 }
 
 impl Default for ServerConf {


### PR DESCRIPTION
Partially addresses #159.

This makes the pub(crate) fields fully pub, and adds a new "manual" constructor.

This is a minor change, however it might be necessary in the future to decouple `pingora-core` from "configuration frontends", as discussed in the issue linked above.

The intent is to use this new interface with `river`, which will bring it's own configuration frontend.