### PR TITLE
Enhance Server::run_forever Method for Stronger Ownership and Exit Semantics

### DIFF
--- a/pingora-core/src/server/mod.rs
+++ b/pingora-core/src/server/mod.rs
@@ -263,7 +263,7 @@ impl Server {
     ///
     /// Note: this function may fork the process for daemonization, so any additional threads created
     /// before this function will be lost to any service logic once this function is called.
-    pub fn run_forever(&mut self) {
+    pub fn run_forever(mut self) -> ! {
         info!("Server starting");
 
         let conf = self.configuration.as_ref();
@@ -328,7 +328,7 @@ impl Server {
             }
         }
         info!("All runtimes exited, exiting now");
-        std::process::exit(0);
+        std::process::exit(0)
     }
 
     fn create_runtime(name: &str, threads: usize, work_steal: bool) -> Runtime {


### PR DESCRIPTION
Refactored `Server::run_forever` to take `self` by value, signaling clear transfer of ownership and ensuring method concludes with explicit exit semantics. This small change improves code clarity and enforces better use patterns.
