### PR TITLE
Adding the stub for the changelog and a config for generating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-02-28
+### Highlights
+- First Public Release of Pingora 🎉

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,87 @@
+# git-cliff ~ default configuration file
+# https://git-cliff.org/docs/configuration
+#
+# Lines starting with "#" are comments.
+# Configuration options are organized into tables and keys.
+# See documentation for more information on available options.
+
+[changelog]
+# changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+  {% if previous.version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/cloudflare/pingora/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+  {% else %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+  {% endif %}\
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+
+### Highlights
+  - Human-written change summaries go here
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# template for the changelog footer
+footer = """
+"""
+# remove the leading and trailing whitespace
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+
+# filter out the commits that are not conventional
+filter_unconventional = false
+
+# process each line of a commit as an individual commit
+split_commits = false
+
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+  { pattern = '\n\w+(?:\-\w+)*:\s+[^\n]+', replace = "\n" },
+  { pattern = '\n+', replace = "\n  " },
+  { pattern = '\s+$', replace = "" }
+]
+
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^doc", group = "<!-- 3 -->📚 Documentation", skip = true  },
+  { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+  { message = "^refactor", group = "<!-- 2 -->🚜 Refactor", skip = true  },
+  { message = "^style", group = "<!-- 5 -->🎨 Styling", skip = true  },
+  { message = "^test", group = "<!-- 6 -->🧪 Testing", skip = true  },
+  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(deps.*\\)", skip = true },
+  { message = "^chore\\(pr\\)", skip = true },
+  { message = "^chore\\(pull\\)", skip = true },
+  { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+  { message = '\S+(?:\s+\S+){6,}', group = "<!--10--> Everything Else" }
+]
+
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+tag_pattern = "[0-9].[0-9].[0-9]"
+topo_order = false


### PR DESCRIPTION
This pr introduces git-cliff as a tool for generating (maintainable) change logs. The changelog attached to this pr was generated with this command:

`git cliff -o -- "0bca116c1027a878469b72352e1e9e3916e85dde..0.1.0"`

I added a place in the template to fill in "Human-generated change summaries" which I replaced with "First Release" message

To generate a new change log, you (or our internal tooling) will run 

`git cliff  --prepend CHANGELOG.md --tag 0.2.0 -- "0.1.0.."`

And you will get 

1. An automated summary based on the new commits (These can be pruned as needed)
2. A place to add the human-written change summary 
3. The rest of the change log

It will look like

```
# Changelog

All notable changes to this project will be documented in this file.

## [0.2.0](https://github.com/cloudflare/pingora/compare/0.1.0...0.2.0) - 2024-04-02
### Highlights
- Human-written change summaries go here

### 🚀 Features

- Enhance Server::new to accept impl Into<Option<T>> for ergonomics
- Implement Keep-Alive header parsing in Session

### 🐛 Bug Fixes

- Fix some comments

### ⚙️ Miscellaneous Tasks

- Ci: add github workflows (#3)
  Add CI workflows for docs, compile, test, and audit. Dependabot also
  included.
- We don't like dependabot (#86)
- Resolve TODOs in the pingora client example

### Everything Else

- Fix TinyUFO ahash in nightly Rust
  I think ahash has this bug where the hash of &u64 and u64 are different
  under nightly build. This works around that.
- Run upstream_response_filter on 304 from upstream cache revalidation
  Previously only the response_filter would run on revalidated responses
  with no way to process the upstream 304.
...

## [0.1.0] - 2024-02-28
### Highlights
- First Public Release of Pingora 🎉
```