### PR TITLE
Add `async_cleanup()` method to `ServerApp` trait

### DIFF
--- a/pingora-core/src/apps/mod.rs
+++ b/pingora-core/src/apps/mod.rs
@@ -51,12 +51,7 @@ pub trait ServerApp {
     ) -> Option<Stream>;
 
     /// This callback will be called once after the service stops listening to its endpoints.
-    fn cleanup(&self) {}
-
-    /// This callback will be called once after the service stops listening to its endpoints.
-    ///
-    /// Used for async cleanup tasks.
-    async fn async_cleanup(&self) {}
+    async fn cleanup(&self) {}
 }
 
 /// This trait defines the interface of an HTTP application.
@@ -82,7 +77,7 @@ pub trait HttpServerApp {
         None
     }
 
-    fn http_cleanup(&self) {}
+    async fn http_cleanup(&self) {}
 }
 
 #[cfg_attr(not(doc_async_trait), async_trait)]
@@ -146,7 +141,7 @@ where
         }
     }
 
-    fn cleanup(&self) {
-        self.http_cleanup()
+    async fn cleanup(&self) {
+        self.http_cleanup().await;
     }
 }

--- a/pingora-core/src/apps/mod.rs
+++ b/pingora-core/src/apps/mod.rs
@@ -52,6 +52,11 @@ pub trait ServerApp {
 
     /// This callback will be called once after the service stops listening to its endpoints.
     fn cleanup(&self) {}
+
+    /// This callback will be called once after the service stops listening to its endpoints.
+    ///
+    /// Used for async cleanup tasks.
+    async fn async_cleanup(&self) {}
 }
 
 /// This trait defines the interface of an HTTP application.

--- a/pingora-core/src/services/listening.rs
+++ b/pingora-core/src/services/listening.rs
@@ -205,8 +205,7 @@ impl<A: ServerApp + Send + Sync + 'static> ServiceTrait for Service<A> {
 
         futures::future::join_all(handlers).await;
         self.listeners.cleanup();
-        self.app_logic.cleanup();
-        self.app_logic.async_cleanup().await;
+        self.app_logic.cleanup().await;
     }
 
     fn name(&self) -> &str {

--- a/pingora-core/src/services/listening.rs
+++ b/pingora-core/src/services/listening.rs
@@ -206,6 +206,7 @@ impl<A: ServerApp + Send + Sync + 'static> ServiceTrait for Service<A> {
         futures::future::join_all(handlers).await;
         self.listeners.cleanup();
         self.app_logic.cleanup();
+        self.app_logic.async_cleanup().await;
     }
 
     fn name(&self) -> &str {

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -605,7 +605,7 @@ where
         self.process_request(session, ctx).await
     }
 
-    fn http_cleanup(&self) {
+    async fn http_cleanup(&self) {
         // Notify all keepalived requests blocking on read_request() to abort
         self.shutdown.notify_waiters();
 


### PR DESCRIPTION
**Motivation:**
In the current implementation of `ServerApp` trait (name the trait if possible), we have a synchronous method `cleanup` designed to clean up resources when a service is stopped. However, as our application evolves and embraces more asynchronous operations, the need for an asynchronous cleanup method has become apparent. This addition will allow for non-blocking resource cleanup, aligning with the asynchronous nature of our other operations.

**Changes:**
Added `async fn async_cleanup()`: Introduced a new asynchronous function, async_cleanup, to the `ServerApp` trait. This method is intended to asynchronously clean up resources, complementing the existing `cleanup` method.
Compatibility Considerations: To ensure backward compatibility and minimize disruption, the existing `cleanup` method remains unchanged. Users can choose between cleanup for synchronous operations and `async_cleanup` for asynchronous operations, depending on their use case.