### PR TITLE
Update `zstd` from 0.9.0 to 0.13.1 and `zstd-safe` from 4.1.1 to 7.1.0 in pingora-header-serde

### DIFF
--- a/pingora-header-serde/Cargo.toml
+++ b/pingora-header-serde/Cargo.toml
@@ -22,8 +22,8 @@ name = "trainer"
 path = "src/trainer.rs"
 
 [dependencies]
-zstd = "0.9.0"
-zstd-safe = "4.1.1"
+zstd = "0.13.1"
+zstd-safe = { version = "7.1.0", features = ["std"] }
 http = { workspace = true }
 bytes = { workspace = true }
 httparse = { workspace = true }

--- a/pingora-header-serde/src/thread_zstd.rs
+++ b/pingora-header-serde/src/thread_zstd.rs
@@ -14,6 +14,7 @@
 
 use std::cell::RefCell;
 use thread_local::ThreadLocal;
+use zstd_safe::{CCtx, DCtx};
 
 /// Each thread will own its compression and decompression CTXes, and they share a single dict
 /// https://facebook.github.io/zstd/zstd_manual.html recommends to reuse ctx per thread
@@ -50,7 +51,7 @@ impl Compression {
         level: i32,
     ) -> Result<usize, &'static str> {
         self.com_context
-            .get_or(|| RefCell::new(zstd_safe::create_cctx()))
+            .get_or(|| RefCell::new(CCtx::create()))
             .borrow_mut()
             .compress_using_dict(destination, source, &self.dict[..], level)
             .map_err(zstd_safe::get_error_name)
@@ -71,7 +72,7 @@ impl Compression {
         destination: &mut C,
     ) -> Result<usize, &'static str> {
         self.de_context
-            .get_or(|| RefCell::new(zstd_safe::create_dctx()))
+            .get_or(|| RefCell::new(DCtx::create()))
             .borrow_mut()
             .decompress_using_dict(destination, source, &self.dict)
             .map_err(zstd_safe::get_error_name)


### PR DESCRIPTION
This PR update `zstd` from 0.9.0 to 0.13.1 and `zstd-safe` from 4.1.1 to 7.1.0 to fix incompatibility with crates using the latest versions of it like `tower_http` (with the feature `async_compression`).