### PR TITLE
Add `Service<HttpProxy<T>>` constructor for providing name

### DIFF
--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -626,3 +626,17 @@ pub fn http_proxy_service<SV>(conf: &Arc<ServerConf>, inner: SV) -> Service<Http
         HttpProxy::new(inner, conf.clone()),
     )
 }
+
+/// Create a [Service] from the user implemented [ProxyHttp].
+///
+/// The returned [Service] can be hosted by a [pingora_core::server::Server] directly.
+pub fn http_proxy_service_with_name<SV>(
+    conf: &Arc<ServerConf>,
+    inner: SV,
+    name: &str,
+) -> Service<HttpProxy<SV>> {
+    Service::new(
+        name.to_string(),
+        HttpProxy::new(inner, conf.clone()),
+    )
+}


### PR DESCRIPTION
This adds a constructor that provides the `Service` name. This is used in `river` for naming the proxy services.

It would be possible to avoid this new constructor, however `HttpProxy::new()` is private, so I went with this to be consistent. I would also be happy to have direct access to the `HttpProxy` constructor.

This is currently needed for the 0.2 release of `river`.