### PR TITLE
Fixes #235 - Replace unmaintained structopt crate by clap

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -36,7 +36,7 @@ log = { workspace = true }
 h2 = { workspace = true }
 lru = { workspace = true }
 nix = "~0.24.3"
-structopt = "0.3"
+clap = { version = "4.5", features = ["derive"] }
 once_cell = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -23,7 +23,7 @@ use log::{debug, trace};
 use pingora_error::{Error, ErrorType::*, OrErr, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use structopt::StructOpt;
+use clap::Parser;
 
 /// The configuration file
 ///
@@ -118,22 +118,22 @@ impl Default for ServerConf {
 /// Command-line options
 ///
 /// Call `Opt::from_args()` to build this object from the process's command line arguments.
-#[derive(StructOpt, Debug)]
-#[structopt(name = "basic")]
+#[derive(Parser, Debug)]
+#[clap(name = "basic")]
 pub struct Opt {
     /// Whether this server should try to upgrade from a running old server
     ///
     /// `-u` or `--upgrade` can be used
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub upgrade: bool,
     /// Whether should run this server in the background
     ///
     /// `-d` or `--daemon` can be used
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub daemon: bool,
     /// Not actually used. This flag is there so that the server is not upset seeing this flag
     /// passed from `cargo test` sometimes
-    #[structopt(long)]
+    #[clap(long)]
     pub nocapture: bool,
     /// Test the configuration and exit
     ///
@@ -143,23 +143,23 @@ pub struct Opt {
     /// service can start before shutting down the old server process.
     ///
     /// `-t` or `--test` can be used
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub test: bool,
     /// The path to the configuration file.
     ///
     /// See [`ServerConf`] for more details of the configuration file.
     ///
     /// `-c` or `--conf` can be used
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub conf: Option<String>,
 }
 
 /// Create the default instance of Opt based on the current command-line args.
-/// This is equivalent to running `Opt::from_args` but does not require the
-/// caller to have included the `structopt::StructOpt`
+/// This is equivalent to running `Opt::parse` but does not require the
+/// caller to have included the `clap::Parser`
 impl Default for Opt {
     fn default() -> Self {
-        Opt::from_args()
+        Opt::parse()
     }
 }
 

--- a/pingora-core/tests/utils/mod.rs
+++ b/pingora-core/tests/utils/mod.rs
@@ -19,7 +19,7 @@ use pingora_core::listeners::Listeners;
 use pingora_core::server::configuration::Opt;
 use pingora_core::server::Server;
 use pingora_core::services::listening::Service;
-use structopt::StructOpt;
+use clap::Parser;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -106,7 +106,7 @@ impl MyServer {
             "tests/pingora_conf.yaml".into(),
         ];
         let server_handle = thread::spawn(|| {
-            entry_point(Some(Opt::from_iter(opts)));
+            entry_point(Some(Opt::parse_from(opts)));
         });
         // wait until the server is up
         thread::sleep(time::Duration::from_secs(2));

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { workspace = true }
 log = { workspace = true }
 h2 = { workspace = true }
 once_cell = { workspace = true }
-structopt = "0.3"
+clap = { version = "4.5", features = ["derive"] }
 regex = "1"
 
 [dev-dependencies]

--- a/pingora-proxy/examples/ctx.rs
+++ b/pingora-proxy/examples/ctx.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 use log::info;
 use std::sync::Mutex;
-use structopt::StructOpt;
+use clap::Parser;
 
 use pingora_core::server::configuration::Opt;
 use pingora_core::server::Server;
@@ -82,7 +82,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/gateway.rs
+++ b/pingora-proxy/examples/gateway.rs
@@ -15,7 +15,7 @@
 use async_trait::async_trait;
 use log::info;
 use prometheus::register_int_counter;
-use structopt::StructOpt;
+use clap::Parser;
 
 use pingora_core::server::configuration::Opt;
 use pingora_core::server::Server;
@@ -114,7 +114,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/load_balancer.rs
+++ b/pingora-proxy/examples/load_balancer.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use log::info;
 use pingora_core::services::background::background_service;
 use std::{sync::Arc, time::Duration};
-use structopt::StructOpt;
+use clap::Parser;
 
 use pingora_core::server::configuration::Opt;
 use pingora_core::server::Server;
@@ -62,7 +62,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/modify_response.rs
+++ b/pingora-proxy/examples/modify_response.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::net::ToSocketAddrs;
-use structopt::StructOpt;
+use clap::Parser;
 
 use pingora_core::server::configuration::Opt;
 use pingora_core::server::Server;
@@ -117,7 +117,7 @@ impl ProxyHttp for Json2Yaml {
 fn main() {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -36,7 +36,7 @@ use pingora_proxy::{ProxyHttp, Session};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::thread;
-use structopt::StructOpt;
+use clap::Parser;
 
 pub struct ExampleProxyHttps {}
 
@@ -469,7 +469,7 @@ fn test_main() {
         "-c".into(),
         "tests/pingora_conf.yaml".into(),
     ];
-    let mut my_server = pingora_core::server::Server::new(Some(Opt::from_iter(opts))).unwrap();
+    let mut my_server = pingora_core::server::Server::new(Some(Opt::parse_from(opts))).unwrap();
     my_server.bootstrap();
 
     let mut proxy_service_http =

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -30,7 +30,7 @@ pingora-proxy = { version = "0.1.0", path = "../pingora-proxy", optional = true,
 pingora-cache = { version = "0.1.0", path = "../pingora-cache", optional = true, default-features = false }
 
 [dev-dependencies]
-structopt = "0.3"
+clap = { version = "4.5", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 matches = "0.1"
 env_logger = "0.9"

--- a/pingora/examples/server.rs
+++ b/pingora/examples/server.rs
@@ -21,7 +21,7 @@ use pingora::services::background::{background_service, BackgroundService};
 use pingora::services::{listening::Service as ListeningService, Service};
 
 use async_trait::async_trait;
-use structopt::StructOpt;
+use clap::Parser;
 use tokio::time::interval;
 
 use std::time::Duration;
@@ -105,7 +105,7 @@ pub fn main() {
 
     print!("{USAGE}");
 
-    let opt = Some(Opt::from_args());
+    let opt = Some(Opt::parse());
     let mut my_server = Server::new(opt).unwrap();
     my_server.bootstrap();
 


### PR DESCRIPTION
See #235 for the rationale. The change itself is pretty straightforward, the only issue here: existing code will have to be adapted (typically a trivial `structopt::StructOpt` => `clap::Parser` and `Opt::from_args` => `Opt::parse` search&replace).

A bunch of tests are failing for me, but that’s unchanged from current main branch.