### PR TITLE
doc: Version update from 1.72.0 to 1.74.0 (released 2023-11-16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Both x86_64 and aarch64 architectures will be supported.
 
 Pingora keeps a rolling MSRV (minimum supported Rust version) policy of 6 months. This means we will accept PRs that upgrade the MSRV as long as the new Rust version used is at least 6 months old.
 
-Our current MSRV is 1.72.
+Our current MSRV is 1.74.0
 
 ## Build Requirements
 


### PR DESCRIPTION
After reviewing the documentation I found that 1.72.0 is still listed as the MSRV, which is 3 months behind the latest version within the 6 month MSRV limit.  Updating will keep the rolling MSRV statement true, add stabilized features from 1.73 + 1.74, and add internal Rust changes from 1.73.

https://doc.rust-lang.org/beta/releases.html#version-1740-2023-11-16

After updating the version I ran:
`cargo clean`
`cargo build`
`cargo fix`
`cargo test`

I found no further changes or issues that I could see needed to be made.
