### PR TITLE
Remove Markdown code from the long CLI help

### DIFF
--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -130,7 +130,7 @@ pub struct Opt {
     )]
     pub upgrade: bool,
 
-    /// Whether should run this server in the background
+    /// Whether this server should run in the background
     #[clap(short, long)]
     pub daemon: bool,
 

--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -119,13 +119,14 @@ impl Default for ServerConf {
 ///
 /// Call `Opt::from_args()` to build this object from the process's command line arguments.
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[clap(name = "basic", long_about = None)]
 pub struct Opt {
     /// Whether this server should try to upgrade from a running old server
     #[clap(
         short,
         long,
-        help = "This is the base set of command line arguments for a pingora-based service"
+        help = "This is the base set of command line arguments for a pingora-based service",
+        long_help = None
     )]
     pub upgrade: bool,
 
@@ -149,14 +150,15 @@ pub struct Opt {
         long,
         help = "This flag is useful for upgrading service where the user wants \
                 to make sure the new service can start before shutting down \
-                the old server process."
+                the old server process.",
+        long_help = None
     )]
     pub test: bool,
 
     /// The path to the configuration file.
     ///
     /// See [`ServerConf`] for more details of the configuration file.
-    #[clap(short, long, help = "The path to the configuration file.")]
+    #[clap(short, long, help = "The path to the configuration file.", long_help = None)]
     pub conf: Option<String>,
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/cloudflare/pingora/issues/231#issuecomment-2130246506, the issue hasn’t been entirely addressed. Clap has a short and a long help variants. While the former has been made proper, the latter still contains doc comments with Markdown code and such.

This change resets the long help, effectively making clap show the short help variant for both `-h` and `--help` command line flags. Also fixing the grammar for the `--daemon` flag description while at it.

```
$ cargo run --example gateway -- --help
basic 
Command-line options

USAGE:
    gateway [OPTIONS]

OPTIONS:
    -c, --conf <CONF>    The path to the configuration file.
    -d, --daemon         Whether this server should run in the background
    -h, --help           Print help information
    -t, --test           This flag is useful for upgrading service where the user wants to make sure
                         the new service can start before shutting down the old server process.
    -u, --upgrade        This is the base set of command line arguments for a pingora-based service
```