### PR TITLE
BackendSelection improvements for least connections

### DIFF
--- a/pingora-load-balancing/src/background.rs
+++ b/pingora-load-balancing/src/background.rs
@@ -16,15 +16,12 @@
 
 use std::time::{Duration, Instant};
 
-use super::{BackendIter, BackendSelection, LoadBalancer};
+use super::{BackendSelection, LoadBalancer};
 use async_trait::async_trait;
 use pingora_core::services::background::BackgroundService;
 
 #[async_trait]
-impl<S: Send + Sync + BackendSelection + 'static> BackgroundService for LoadBalancer<S>
-where
-    S::Iter: BackendIter,
-{
+impl<S: Send + Sync + BackendSelection + 'static> BackgroundService for LoadBalancer<S> {
     async fn start(&self, shutdown: pingora_core::server::ShutdownWatch) -> () {
         // 136 years
         const NEVER: Duration = Duration::from_secs(u32::MAX as u64);

--- a/pingora-load-balancing/src/lib.rs
+++ b/pingora-load-balancing/src/lib.rs
@@ -35,8 +35,8 @@ pub mod selection;
 
 use discovery::ServiceDiscovery;
 use health_check::Health;
+use selection::BackendSelection;
 use selection::UniqueIterator;
-use selection::{BackendIter, BackendSelection};
 
 pub mod prelude {
     pub use crate::health_check::TcpHealthCheck;
@@ -267,7 +267,8 @@ impl Backends {
 /// needs to be run as a [pingora_core::services::background::BackgroundService].
 pub struct LoadBalancer<S> {
     backends: Backends,
-    selector: ArcSwap<S>,
+    /// Backend selection mechanism
+    pub selector: ArcSwap<S>,
     /// How frequent the health check logic (if set) should run.
     ///
     /// If `None`, the health check logic will only run once at the beginning.
@@ -283,7 +284,6 @@ pub struct LoadBalancer<S> {
 impl<'a, S: BackendSelection> LoadBalancer<S>
 where
     S: BackendSelection + 'static,
-    S::Iter: BackendIter,
 {
     /// Build a [LoadBalancer] with static backends created from the iter.
     ///

--- a/pingora-load-balancing/src/lib.rs
+++ b/pingora-load-balancing/src/lib.rs
@@ -305,7 +305,7 @@ where
 
     /// Build a [LoadBalancer] with the given [Backends].
     pub fn from_backends(backends: Backends) -> Self {
-        let selector = ArcSwap::new(Arc::new(S::build(&backends.get_backend())));
+        let selector = ArcSwap::new(Arc::new(S::build(&backends.get_backend(), None)));
         LoadBalancer {
             backends,
             selector,
@@ -321,8 +321,10 @@ where
     /// is running as a background service.
     pub async fn update(&self) -> Result<()> {
         if self.backends.update().await? {
-            self.selector
-                .store(Arc::new(S::build(&self.backends.get_backend())))
+            self.selector.store(Arc::new(S::build(
+                &self.backends.get_backend(),
+                Some(self.selector.load_full()),
+            )))
         }
         Ok(())
     }

--- a/pingora-load-balancing/src/selection/consistent.rs
+++ b/pingora-load-balancing/src/selection/consistent.rs
@@ -29,7 +29,7 @@ pub struct KetamaHashing {
 impl BackendSelection for KetamaHashing {
     type Iter = OwnedNodeIterator;
 
-    fn build(backends: &BTreeSet<Backend>) -> Self {
+    fn build(backends: &BTreeSet<Backend>, _previous: Option<Arc<Self>>) -> Self {
         let buckets: Vec<_> = backends
             .iter()
             .filter_map(|b| {
@@ -84,7 +84,7 @@ mod test {
         let b2 = Backend::new("1.0.0.1:80").unwrap();
         let b3 = Backend::new("1.0.0.255:80").unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash = Arc::new(KetamaHashing::build(&backends));
+        let hash = Arc::new(KetamaHashing::build(&backends, None));
 
         let mut iter = hash.iter(b"test0");
         assert_eq!(iter.next(), Some(&b2));
@@ -109,7 +109,7 @@ mod test {
 
         // remove b3
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone()]);
-        let hash = Arc::new(KetamaHashing::build(&backends));
+        let hash = Arc::new(KetamaHashing::build(&backends, None));
         let mut iter = hash.iter(b"test0");
         assert_eq!(iter.next(), Some(&b2));
         let mut iter = hash.iter(b"test1");

--- a/pingora-load-balancing/src/selection/mod.rs
+++ b/pingora-load-balancing/src/selection/mod.rs
@@ -26,7 +26,7 @@ use weighted::Weighted;
 /// [BackendSelection] is the interface to implement backend selection mechanisms.
 pub trait BackendSelection {
     /// The [BackendIter] returned from iter() below.
-    type Iter;
+    type Iter: BackendIter;
     /// The function to create a [BackendSelection] implementation.
     fn build(backends: &BTreeSet<Backend>) -> Self;
     /// Select backends for a given key.
@@ -34,9 +34,7 @@ pub trait BackendSelection {
     /// An [BackendIter] should be returned. The first item in the iter is the first
     /// choice backend. The user should continue to iterate over it if the first backend
     /// cannot be used due to its health or other reasons.
-    fn iter(self: &Arc<Self>, key: &[u8]) -> Self::Iter
-    where
-        Self::Iter: BackendIter;
+    fn iter(self: &Arc<Self>, key: &[u8]) -> Self::Iter;
 }
 
 /// An iterator to find the suitable backend

--- a/pingora-load-balancing/src/selection/mod.rs
+++ b/pingora-load-balancing/src/selection/mod.rs
@@ -28,7 +28,8 @@ pub trait BackendSelection {
     /// The [BackendIter] returned from iter() below.
     type Iter: BackendIter;
     /// The function to create a [BackendSelection] implementation.
-    fn build(backends: &BTreeSet<Backend>) -> Self;
+    /// `previous` is previous instance of self, when it's created during backend update 
+    fn build(backends: &BTreeSet<Backend>, previous: Option<Arc<Self>>) -> Self;
     /// Select backends for a given key.
     ///
     /// An [BackendIter] should be returned. The first item in the iter is the first

--- a/pingora-load-balancing/src/selection/mod.rs
+++ b/pingora-load-balancing/src/selection/mod.rs
@@ -28,7 +28,7 @@ pub trait BackendSelection {
     /// The [BackendIter] returned from iter() below.
     type Iter: BackendIter;
     /// The function to create a [BackendSelection] implementation.
-    /// `previous` is previous instance of self, when it's created during backend update 
+    /// `previous` is previous instance of self, when it's created during backend update
     fn build(backends: &BTreeSet<Backend>, previous: Option<Arc<Self>>) -> Self;
     /// Select backends for a given key.
     ///

--- a/pingora-load-balancing/src/selection/weighted.rs
+++ b/pingora-load-balancing/src/selection/weighted.rs
@@ -32,7 +32,7 @@ pub struct Weighted<H = FnvHasher> {
 impl<H: SelectionAlgorithm> BackendSelection for Weighted<H> {
     type Iter = WeightedIterator<H>;
 
-    fn build(backends: &BTreeSet<Backend>) -> Self {
+    fn build(backends: &BTreeSet<Backend>, _previous: Option<Arc<Self>>) -> Self {
         assert!(
             backends.len() <= u16::MAX as usize,
             "support up to 2^16 backends"
@@ -113,7 +113,7 @@ mod test {
         b2.weight = 10; // 10x than the rest
         let b3 = Backend::new("1.0.0.255:80").unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash: Arc<Weighted> = Arc::new(Weighted::build(&backends));
+        let hash: Arc<Weighted> = Arc::new(Weighted::build(&backends, None));
 
         // same hash iter over
         let mut iter = hash.iter(b"test");
@@ -155,7 +155,7 @@ mod test {
         b2.weight = 8; // 8x than the rest
         let b3 = Backend::new("1.0.0.255:80").unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash: Arc<Weighted<RoundRobin>> = Arc::new(Weighted::build(&backends));
+        let hash: Arc<Weighted<RoundRobin>> = Arc::new(Weighted::build(&backends, None));
 
         // same hash iter over
         let mut iter = hash.iter(b"test");
@@ -191,7 +191,7 @@ mod test {
         b2.weight = 8; // 8x than the rest
         let b3 = Backend::new("1.0.0.255:80").unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash: Arc<Weighted<Random>> = Arc::new(Weighted::build(&backends));
+        let hash: Arc<Weighted<Random>> = Arc::new(Weighted::build(&backends, None));
 
         let mut count = HashMap::new();
         count.insert(b1.clone(), 0);

--- a/pingora-proxy/examples/multi_lb.rs
+++ b/pingora-proxy/examples/multi_lb.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use pingora_core::{prelude::*, services::background::GenBackgroundService};
 use pingora_load_balancing::{
     health_check::TcpHealthCheck,
-    selection::{BackendIter, BackendSelection, RoundRobin},
+    selection::{BackendSelection, RoundRobin},
     LoadBalancer,
 };
 use pingora_proxy::{http_proxy_service, ProxyHttp, Session};
@@ -56,7 +56,6 @@ impl ProxyHttp for Router {
 fn build_cluster_service<S>(upstreams: &[&str]) -> GenBackgroundService<LoadBalancer<S>>
 where
     S: BackendSelection + 'static,
-    S::Iter: BackendIter,
 {
     let mut cluster = LoadBalancer::try_from_iter(upstreams).unwrap();
     cluster.set_health_check(TcpHealthCheck::new());


### PR DESCRIPTION
Hi. I wanted to implement my own backend selection (basically least connections), but faced some inconvenience and issues.

To address Inconvenience:
Moved `BackendIter` bound into `BackendSelection::Iter`. 
It was only used with this bound everywhere anyway, even docs says that Iter should be BackendIter.
Can't see any reason why it's like that. Tested against rust 1.72 to verify that it satisfies msrv.
It doesn't break any existing code, just makes bound `S::Iter: BackendIter` redundant.

Issues:
1. `selector` field in `LoadBalancer` is private, but I needed to access it to share some handle that will be used to notify selector of pending upstream requests.
It's possible to achieve this by other means (either global state, but then it's hard to share code, or more api churn and changing public interfaces, which I don't want to do here).

2. When backends are updated new instance of `BackendSelection` is created and replaced, but to keep handle from previous selector I had to resort to global state. So I added `previous: Option<Arc<Self>>` argument that will be passed in LoadBalancer::update, so it's possible to keep provided handle or some other state. This is somewhat breaking change.
 
Related Issue: https://github.com/cloudflare/pingora/issues/144
Maybe later after my experiments will make a PR for least connections. 