### PR TITLE
Fixes #270 - Add `Session::digest_mut()` method

### DIFF
--- a/pingora-core/src/connectors/http/v2.rs
+++ b/pingora-core/src/connectors/http/v2.rs
@@ -102,6 +102,10 @@ impl ConnectionRef {
         &self.0.digest
     }
 
+    pub fn digest_mut(&mut self) -> Option<&mut Digest> {
+        Arc::get_mut(&mut self.0).map(|inner| &mut inner.digest)
+    }
+
     pub fn ping_timedout(&self) -> bool {
         self.0.ping_timeout_occurred.load(Ordering::Relaxed)
     }

--- a/pingora-core/src/protocols/http/client.rs
+++ b/pingora-core/src/protocols/http/client.rs
@@ -159,6 +159,17 @@ impl HttpSession {
         }
     }
 
+    /// Return a mutable [Digest] reference for the connection
+    ///
+    /// For reused connection, the timing in the digest will reflect its initial handshakes
+    /// The caller should check if the connection is reused to avoid misuse of the timing field
+    pub fn digest_mut(&mut self) -> Option<&mut Digest> {
+        match self {
+            Self::H1(s) => Some(s.digest_mut()),
+            Self::H2(s) => s.digest_mut(),
+        }
+    }
+
     /// Return the server (peer) address of the connection.
     pub fn server_addr(&self) -> Option<&SocketAddr> {
         match self {

--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -365,6 +365,14 @@ impl Session {
         }
     }
 
+    /// Return a mutable digest reference for the session.
+    pub fn digest_mut(&mut self) -> Option<&mut Digest> {
+        match self {
+            Self::H1(s) => Some(s.digest_mut()),
+            Self::H2(s) => s.digest_mut(),
+        }
+    }
+
     /// Return the client (peer) address of the connnection.
     pub fn client_addr(&self) -> Option<&SocketAddr> {
         match self {

--- a/pingora-core/src/protocols/http/v1/client.rs
+++ b/pingora-core/src/protocols/http/v1/client.rs
@@ -635,6 +635,10 @@ impl HttpSession {
         &self.digest
     }
 
+    pub fn digest_mut(&mut self) -> &mut Digest {
+        &mut self.digest
+    }
+
     /// Return the server (peer) address recorded in the connection digest.
     pub fn server_addr(&self) -> Option<&SocketAddr> {
         self.digest()

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -783,6 +783,11 @@ impl HttpSession {
         &self.digest
     }
 
+    /// Return a mutable [Digest] reference for the connection.
+    pub fn digest_mut(&mut self) -> &mut Digest {
+        &mut self.digest
+    }
+
     /// Return the client (peer) address of the underlying connnection.
     pub fn client_addr(&self) -> Option<&SocketAddr> {
         self.digest()

--- a/pingora-core/src/protocols/http/v2/client.rs
+++ b/pingora-core/src/protocols/http/v2/client.rs
@@ -310,6 +310,14 @@ impl Http2Session {
         Some(self.conn.digest())
     }
 
+    /// Return a mutable [Digest] reference for the connection
+    ///
+    /// For reused connection, the timing in the digest will reflect its initial handshakes
+    /// The caller should check if the connection is reused to avoid misuse the timing field
+    pub fn digest_mut(&mut self) -> Option<&mut Digest> {
+        self.conn.digest_mut()
+    }
+
     /// Return the server (peer) address recorded in the connection digest.
     pub fn server_addr(&self) -> Option<&SocketAddr> {
         self.conn

--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -454,6 +454,11 @@ impl HttpSession {
         Some(&self.digest)
     }
 
+    /// Return a mutable [Digest] reference for the connection.
+    pub fn digest_mut(&mut self) -> Option<&mut Digest> {
+        Arc::get_mut(&mut self.digest)
+    }
+
     /// Return the server (local) address recorded in the connection digest.
     pub fn server_addr(&self) -> Option<&SocketAddr> {
         self.digest.socket_digest.as_ref().map(|d| d.local_addr())?


### PR DESCRIPTION
This change allows adjusting the session metadata. See #270 for one scenario where this might be necessary.