### PR TITLE
Fixes #261 - Better `Default` implementation for `Opt`

### DIFF
--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -118,7 +118,7 @@ impl Default for ServerConf {
 /// Command-line options
 ///
 /// Call `Opt::from_args()` to build this object from the process's command line arguments.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[clap(name = "basic", long_about = None)]
 pub struct Opt {
     /// Whether this server should try to upgrade from a running old server
@@ -160,15 +160,6 @@ pub struct Opt {
     /// See [`ServerConf`] for more details of the configuration file.
     #[clap(short, long, help = "The path to the configuration file.", long_help = None)]
     pub conf: Option<String>,
-}
-
-/// Create the default instance of Opt based on the current command-line args.
-/// This is equivalent to running `Opt::parse` but does not require the
-/// caller to have included the `clap::Parser`
-impl Default for Opt {
-    fn default() -> Self {
-        Opt::parse()
-    }
 }
 
 impl ServerConf {


### PR DESCRIPTION
@johnhurt Sorry about grabbing this, Github doesn’t notify me about issues being assigned, so I only noticed when I already had everything done. Feel free to close this if you have a fix ready.

This replaces the `Default` implementation for `Opt` by an auto-generated one which happens to produce exactly the expected results (all boolean flags set to `false` and configuration file to `None`) and none of the side-effects listed in #261.

I checked and there is no piece of code in the repository (including tests and examples) actually depending on this `Default` implementation. So whatever the doc string is saying here, nothing was actually using it as an alias for `Opt::parse`. Given that, I considered not creating an alternative for calling `Opt::parse` without a `clap::Parser` dependency the best course of action.