### PR TITLE
Added `init_downstream_modules` phase allowing modules to be set up before startup

### DIFF
--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -40,6 +40,11 @@ pub trait ProxyHttp {
         ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>>;
 
+    /// Set up downstream modules.
+    ///
+    /// In this phase, users can add or configure modules before the server starts up.
+    fn init_downstream_modules(&self, _modules: &mut HttpModules) {}
+
     /// Handle the incoming request.
     ///
     /// In this phase, users can parse, validate, rate limit, perform access control and/or


### PR DESCRIPTION
This addresses a roadblock I’ve hit trying to make the new downstream modules mechanism work for me: these cannot be configured from within the `HttpProxy` instance. The configuration has to happen after `http_proxy_service` has been called, but at this point the `HttpProxy` instance has been moved into the service and is no longer accessible. In order to adjust the compression level for example some code outside the actual handler would have to mess with the service configuration which is a significant logic break.

In case of compression this can be addressed by adjusting compression level in `early_request_filter`. When the handler wants to add its own module however (helps remove some work-arounds I’ve added before), this option is rather suboptimal.

So I’ve added an `init_downstream_module` phase where `HttpProxy` can adjust modules to its liking.