### PR TITLE
Fixed `Session::write_response_header_ref` bypassing downstream modules

### DIFF
--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -368,7 +368,8 @@ impl Session {
         resp: &ResponseHeader,
         end_of_stream: bool,
     ) -> Result<(), Box<Error>> {
-        self.write_response_header(Box::new(resp.clone()), end_of_stream).await
+        self.write_response_header(Box::new(resp.clone()), end_of_stream)
+            .await
     }
 
     /// Write the given HTTP response body chunk to the downstream

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -362,6 +362,15 @@ impl Session {
         self.downstream_session.write_response_header(resp).await
     }
 
+    /// Similar to `write_response_header()`, this fn will clone the `resp` internally
+    pub async fn write_response_header_ref(
+        &mut self,
+        resp: &ResponseHeader,
+        end_of_stream: bool,
+    ) -> Result<(), Box<Error>> {
+        self.write_response_header(Box::new(resp.clone()), end_of_stream).await
+    }
+
     /// Write the given HTTP response body chunk to the downstream
     ///
     /// Different from directly calling [HttpSession::write_response_body], this function also
@@ -514,7 +523,7 @@ impl<SV> HttpProxy<SV> {
                     // The hook can choose to write its own response, but if it doesn't, we respond
                     // with a generic 502
                     if session.response_written().is_none() {
-                        match session.write_response_header_ref(&BAD_GATEWAY).await {
+                        match session.write_response_header_ref(&BAD_GATEWAY, true).await {
                             Ok(()) => {}
                             Err(e) => {
                                 self.handle_error(


### PR DESCRIPTION
As mentioned in https://github.com/cloudflare/pingora/issues/206#issuecomment-2168764571, `pingora_proxy::Session::write_response_header_ref` will currently call directly into the downstream session and bypass downstream modules. This might mess up compression for example.

Instead of duplicating the code triggering modules I decided to make this call `Session::write_response_header` with a cloned `resp` – this is how this works anyway, merely a few levels further down.