### PR TITLE
Add "Metadata" field to `Backend`s

### DIFF
--- a/pingora-core/src/protocols/l4/ext.rs
+++ b/pingora-core/src/protocols/l4/ext.rs
@@ -356,7 +356,7 @@ fn wrap_os_connect_error(e: std::io::Error, context: String) -> Box<Error> {
 }
 
 /// The configuration for TCP keepalive
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TcpKeepalive {
     /// The time a connection needs to be idle before TCP begins sending out keep-alive probes.
     pub idle: Duration,

--- a/pingora-core/src/protocols/ssl/mod.rs
+++ b/pingora-core/src/protocols/ssl/mod.rs
@@ -178,7 +178,7 @@ impl<T> Ssl for SslStream<T> {
 }
 
 /// The protocol for Application-Layer Protocol Negotiation
-#[derive(Hash, Clone, Debug)]
+#[derive(Hash, Clone, Debug, PartialEq, Eq)]
 pub enum ALPN {
     /// Prefer HTTP/1.1 only
     H1,

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -19,7 +19,7 @@ use pingora_error::{
     ErrorType::{InternalError, SocketError},
     OrErr, Result,
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::Deref};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr as InetSocketAddr, ToSocketAddrs as ToInetSocketAddrs};
@@ -55,6 +55,21 @@ impl Clone for Tracer {
     fn clone(&self) -> Self {
         Tracer(self.0.boxed_clone())
     }
+}
+
+impl PartialEq for Tracer {
+    fn eq(&self, other: &Self) -> bool {
+        // This is a VERY simple check for "pointer equality". We could also require that
+        // Tracer have an Eq/PartialEq implementation as part of the supertrait, however
+        // currently this is only provided to allow HttpPeer to be Eq.
+        let a: *const dyn Tracing = self.0.deref();
+        let b: *const dyn Tracing = other.0.deref();
+        core::ptr::addr_eq(a, b)
+    }
+}
+
+impl Eq for Tracer {
+
 }
 
 /// [`Peer`] defines the interface to communicate with the [`crate::connectors`] regarding where to
@@ -257,7 +272,7 @@ impl Peer for BasicPeer {
 }
 
 /// Define whether to connect via http or https
-#[derive(Hash, Clone, Debug, PartialEq)]
+#[derive(Hash, Clone, Debug, PartialEq, Eq)]
 pub enum Scheme {
     HTTP,
     HTTPS,
@@ -285,7 +300,7 @@ impl Scheme {
 /// The preferences to connect to a remote server
 ///
 /// See [`Peer`] for the meaning of the fields
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerOptions {
     pub bind_to: Option<InetSocketAddr>,
     pub connection_timeout: Option<Duration>,
@@ -396,7 +411,7 @@ impl Display for PeerOptions {
 }
 
 /// A peer representing the remote HTTP server to connect to
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HttpPeer {
     pub _address: SocketAddr,
     pub scheme: Scheme,
@@ -552,7 +567,7 @@ impl Peer for HttpPeer {
 }
 
 /// The proxy settings to connect to the remote server, CONNECT only for now
-#[derive(Debug, Hash, Clone)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub struct Proxy {
     pub next_hop: Box<Path>, // for now this will be the path to the UDS
     pub host: String,        // the proxied host. Could be either IP addr or hostname.

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -19,7 +19,6 @@ use pingora_error::{
     ErrorType::{InternalError, SocketError},
     OrErr, Result,
 };
-use std::{collections::BTreeMap, ops::Deref};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr as InetSocketAddr, ToSocketAddrs as ToInetSocketAddrs};
@@ -28,6 +27,7 @@ use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use std::{collections::BTreeMap, ops::Deref};
 
 use crate::protocols::l4::socket::SocketAddr;
 use crate::protocols::ConnFdReusable;
@@ -68,9 +68,7 @@ impl PartialEq for Tracer {
     }
 }
 
-impl Eq for Tracer {
-
-}
+impl Eq for Tracer {}
 
 /// [`Peer`] defines the interface to communicate with the [`crate::connectors`] regarding where to
 /// connect to and how to connect to it.

--- a/pingora-core/src/utils/mod.rs
+++ b/pingora-core/src/utils/mod.rs
@@ -156,6 +156,16 @@ pub struct CertKey {
     key: PKey<Private>,
 }
 
+impl PartialEq for CertKey {
+    fn eq(&self, other: &Self) -> bool {
+        // Use destructuring to make sure that we update this for new fields
+        let CertKey { certificates, key } = self;
+        certificates.eq(&other.certificates) && key.public_eq(&other.key)
+    }
+}
+
+impl Eq for CertKey {}
+
 impl CertKey {
     /// Create a new `CertKey` given a list of certificates and a private key.
     pub fn new(certificates: Vec<X509>, key: PKey<Private>) -> CertKey {

--- a/pingora-load-balancing/src/background.rs
+++ b/pingora-load-balancing/src/background.rs
@@ -14,7 +14,10 @@
 
 //! Implement [BackgroundService] for [LoadBalancer]
 
-use std::{hash::Hash, time::{Duration, Instant}};
+use std::{
+    hash::Hash,
+    time::{Duration, Instant},
+};
 
 use super::{BackendIter, BackendSelection, LoadBalancer};
 use async_trait::async_trait;

--- a/pingora-load-balancing/src/background.rs
+++ b/pingora-load-balancing/src/background.rs
@@ -28,7 +28,7 @@ impl<S, M> BackgroundService for LoadBalancer<S, M>
 where
     S: Send + Sync + BackendSelection<Metadata = M> + 'static,
     S::Iter: BackendIter<Metadata = M>,
-    M: Hash + PartialEq + Clone + core::fmt::Debug + Send + Sync + 'static,
+    M: Hash + Eq + Clone + core::fmt::Debug + Send + Sync + 'static,
 {
     async fn start(&self, shutdown: pingora_core::server::ShutdownWatch) -> () {
         // 136 years

--- a/pingora-load-balancing/src/background.rs
+++ b/pingora-load-balancing/src/background.rs
@@ -14,16 +14,18 @@
 
 //! Implement [BackgroundService] for [LoadBalancer]
 
-use std::time::{Duration, Instant};
+use std::{hash::Hash, time::{Duration, Instant}};
 
 use super::{BackendIter, BackendSelection, LoadBalancer};
 use async_trait::async_trait;
 use pingora_core::services::background::BackgroundService;
 
 #[async_trait]
-impl<S: Send + Sync + BackendSelection + 'static> BackgroundService for LoadBalancer<S>
+impl<S, M> BackgroundService for LoadBalancer<S, M>
 where
-    S::Iter: BackendIter,
+    S: Send + Sync + BackendSelection<Metadata = M> + 'static,
+    S::Iter: BackendIter<Metadata = M>,
+    M: Hash + PartialEq + Clone + core::fmt::Debug + Send + Sync + 'static,
 {
     async fn start(&self, shutdown: pingora_core::server::ShutdownWatch) -> () {
         // 136 years

--- a/pingora-load-balancing/src/discovery.rs
+++ b/pingora-load-balancing/src/discovery.rs
@@ -69,7 +69,7 @@ where
 
 impl<M> Static<M>
 where
-    M: Ord + Clone
+    M: Ord + Clone,
 {
     /// Create a new boxed [Static] service discovery with the given backends.
     pub fn new(backends: BTreeSet<Backend<M>>) -> Box<Self> {

--- a/pingora-load-balancing/src/discovery.rs
+++ b/pingora-load-balancing/src/discovery.rs
@@ -22,7 +22,7 @@ use std::hash::Hash;
 use std::io::Result as IoResult;
 use std::net::ToSocketAddrs;
 use std::{
-    collections::{HashSet, HashMap},
+    collections::{HashMap, HashSet},
     sync::Arc,
 };
 

--- a/pingora-load-balancing/src/health_check.rs
+++ b/pingora-load-balancing/src/health_check.rs
@@ -89,7 +89,6 @@ where
 }
 
 impl<M> TcpHealthCheck<M> {
-
     /// Create a new [TcpHealthCheck] that tries to establish a TLS connection.
     ///
     /// The default values are the same as [Self::new()].

--- a/pingora-load-balancing/src/health_check.rs
+++ b/pingora-load-balancing/src/health_check.rs
@@ -339,13 +339,16 @@ mod test {
     use super::*;
     use crate::SocketAddr;
 
+    type TestMetadata = u32;
+
     #[tokio::test]
     async fn test_tcp_check() {
-        let tcp_check = TcpHealthCheck::default();
+        let tcp_check = TcpHealthCheck::<TestMetadata>::default();
 
         let backend = Backend {
             addr: SocketAddr::Inet("1.1.1.1:80".parse().unwrap()),
             weight: 1,
+            metadata: 10,
         };
 
         assert!(tcp_check.check(&backend).await.is_ok());
@@ -353,6 +356,7 @@ mod test {
         let backend = Backend {
             addr: SocketAddr::Inet("1.1.1.1:79".parse().unwrap()),
             weight: 1,
+            metadata: 20,
         };
 
         assert!(tcp_check.check(&backend).await.is_err());
@@ -364,6 +368,7 @@ mod test {
         let backend = Backend {
             addr: SocketAddr::Inet("1.1.1.1:443".parse().unwrap()),
             weight: 1,
+            metadata: 30,
         };
 
         assert!(tls_check.check(&backend).await.is_ok());
@@ -376,6 +381,7 @@ mod test {
         let backend = Backend {
             addr: SocketAddr::Inet("1.1.1.1:443".parse().unwrap()),
             weight: 1,
+            metadata: 40,
         };
 
         assert!(https_check.check(&backend).await.is_ok());
@@ -398,6 +404,7 @@ mod test {
         let backend = Backend {
             addr: SocketAddr::Inet("1.1.1.1:80".parse().unwrap()),
             weight: 1,
+            metadata: 60,
         };
 
         http_check.check(&backend).await.unwrap();

--- a/pingora-load-balancing/src/health_check.rs
+++ b/pingora-load-balancing/src/health_check.rs
@@ -21,16 +21,18 @@ use pingora_core::connectors::{http::Connector as HttpConnector, TransportConnec
 use pingora_core::upstreams::peer::{BasicPeer, HttpPeer, Peer};
 use pingora_error::{Error, ErrorType::CustomCode, Result};
 use pingora_http::{RequestHeader, ResponseHeader};
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
 /// [HealthCheck] is the interface to implement health check for backends
 #[async_trait]
 pub trait HealthCheck {
+    type Metadata;
     /// Check the given backend.
     ///
     /// `Ok(())`` if the check passes, otherwise the check fails.
-    async fn check(&self, target: &Backend) -> Result<()>;
+    async fn check(&self, target: &Backend<Self::Metadata>) -> Result<()>;
     /// This function defines how many *consecutive* checks should flip the health of a backend.
     ///
     /// For example: with `success``: `true`: this function should return the
@@ -41,7 +43,7 @@ pub trait HealthCheck {
 /// TCP health check
 ///
 /// This health check checks if a TCP (or TLS) connection can be established to a given backend.
-pub struct TcpHealthCheck {
+pub struct TcpHealthCheck<M> {
     /// Number of successful checks to flip from unhealthy to healthy.
     pub consecutive_success: usize,
     /// Number of failed checks to flip from healthy to unhealthy.
@@ -56,9 +58,10 @@ pub struct TcpHealthCheck {
     /// set, it will also try to establish a TLS connection on top of the TCP connection.
     pub peer_template: BasicPeer,
     connector: TransportConnector,
+    pd: PhantomData<M>,
 }
 
-impl Default for TcpHealthCheck {
+impl<M> Default for TcpHealthCheck<M> {
     fn default() -> Self {
         let mut peer_template = BasicPeer::new("0.0.0.0:1");
         peer_template.options.connection_timeout = Some(Duration::from_secs(1));
@@ -67,18 +70,25 @@ impl Default for TcpHealthCheck {
             consecutive_failure: 1,
             peer_template,
             connector: TransportConnector::new(None),
+            pd: PhantomData,
         }
     }
 }
 
-impl TcpHealthCheck {
+impl<M> TcpHealthCheck<M>
+where
+    M: Default,
+{
     /// Create a new [TcpHealthCheck] with the following default values
     /// * connect timeout: 1 second
     /// * consecutive_success: 1
     /// * consecutive_failure: 1
     pub fn new() -> Box<Self> {
-        Box::<TcpHealthCheck>::default()
+        Box::<TcpHealthCheck<M>>::default()
     }
+}
+
+impl<M> TcpHealthCheck<M> {
 
     /// Create a new [TcpHealthCheck] that tries to establish a TLS connection.
     ///
@@ -96,7 +106,12 @@ impl TcpHealthCheck {
 }
 
 #[async_trait]
-impl HealthCheck for TcpHealthCheck {
+impl<M> HealthCheck for TcpHealthCheck<M>
+where
+    M: Clone + Send + Sync + 'static,
+{
+    type Metadata = M;
+
     fn health_threshold(&self, success: bool) -> usize {
         if success {
             self.consecutive_success
@@ -105,10 +120,10 @@ impl HealthCheck for TcpHealthCheck {
         }
     }
 
-    async fn check(&self, target: &Backend) -> Result<()> {
+    async fn check(&self, target: &Backend<M>) -> Result<()> {
         let mut peer = self.peer_template.clone();
         peer._address = target.addr.clone();
-        self.connector.get_stream(&peer).await.map(|_| {})
+        self.connector.get_stream(&peer).await.map(drop)
     }
 }
 
@@ -117,7 +132,7 @@ type Validator = Box<dyn Fn(&ResponseHeader) -> Result<()> + Send + Sync>;
 /// HTTP health check
 ///
 /// This health check checks if it can receive the expected HTTP(s) response from the given backend.
-pub struct HttpHealthCheck {
+pub struct HttpHealthCheck<M> {
     /// Number of successful checks to flip from unhealthy to healthy.
     pub consecutive_success: usize,
     /// Number of failed checks to flip from healthy to unhealthy.
@@ -147,9 +162,11 @@ pub struct HttpHealthCheck {
     /// Sometimes the health check endpoint lives one a different port than the actual backend.
     /// Setting this option allows the health check to perform on the given port of the backend IP.
     pub port_override: Option<u16>,
+
+    pub pd: PhantomData<M>,
 }
 
-impl HttpHealthCheck {
+impl<M> HttpHealthCheck<M> {
     /// Create a new [HttpHealthCheck] with the following default settings
     /// * connect timeout: 1 second
     /// * read timeout: 1 second
@@ -174,6 +191,7 @@ impl HttpHealthCheck {
             req,
             validator: None,
             port_override: None,
+            pd: PhantomData,
         }
     }
 
@@ -184,7 +202,12 @@ impl HttpHealthCheck {
 }
 
 #[async_trait]
-impl HealthCheck for HttpHealthCheck {
+impl<M> HealthCheck for HttpHealthCheck<M>
+where
+    M: Clone + Sync,
+{
+    type Metadata = M;
+
     fn health_threshold(&self, success: bool) -> usize {
         if success {
             self.consecutive_success
@@ -193,7 +216,7 @@ impl HealthCheck for HttpHealthCheck {
         }
     }
 
-    async fn check(&self, target: &Backend) -> Result<()> {
+    async fn check(&self, target: &Backend<M>) -> Result<()> {
         let mut peer = self.peer_template.clone();
         peer._address = target.addr.clone();
         if let Some(port) = self.port_override {

--- a/pingora-load-balancing/src/lib.rs
+++ b/pingora-load-balancing/src/lib.rs
@@ -21,7 +21,7 @@ use futures::FutureExt;
 use pingora_core::protocols::l4::socket::SocketAddr;
 use pingora_error::{ErrorType, OrErr, Result};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::io::Result as IoResult;
 use std::net::ToSocketAddrs;
@@ -147,11 +147,7 @@ where
     M: Eq + Hash,
 {
     /// Return true when the new is different from the current set of backends
-    fn do_update(
-        &self,
-        new_backends: HashSet<Backend<M>>,
-        enablement: HashMap<u64, bool>,
-    ) -> bool {
+    fn do_update(&self, new_backends: HashSet<Backend<M>>, enablement: HashMap<u64, bool>) -> bool {
         if (**self.backends.load()) != new_backends {
             let old_health = self.health.load();
             let mut health = HashMap::with_capacity(new_backends.len());
@@ -328,9 +324,7 @@ where
     where
         A: ToSocketAddrs,
     {
-        let iter = iter.into_iter().map(|a| {
-            (a, M::default())
-        });
+        let iter = iter.into_iter().map(|a| (a, M::default()));
         let discovery = discovery::Static::<M>::try_from_iter(iter)?;
         let backends = Backends::<M>::new(discovery);
         let lb = Self::from_backends(backends);

--- a/pingora-load-balancing/src/lib.rs
+++ b/pingora-load-balancing/src/lib.rs
@@ -46,28 +46,28 @@ pub mod prelude {
 
 /// [Backend] represents a server to proxy or connect to.
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct Backend {
+pub struct Backend<M> {
     /// The address to the backend server.
     pub addr: SocketAddr,
     /// The relative weight of the server. Load balancing algorithms will
     /// proportionally distributed traffic according to this value.
     pub weight: usize,
+    /// Additional, optional metadata
+    pub metadata: M,
 }
 
-impl Backend {
+impl Backend<()> {
     /// Create a new [Backend] with `weight` 1. The function will try to parse
     ///  `addr` into a [std::net::SocketAddr].
     pub fn new(addr: &str) -> Result<Self> {
-        let addr = addr
-            .parse()
-            .or_err(ErrorType::InternalError, "invalid socket addr")?;
-        Ok(Backend {
-            addr: SocketAddr::Inet(addr),
-            weight: 1,
-        })
-        // TODO: UDS
+        Self::new_with_meta(addr, ())
     }
+}
 
+impl<M> Backend<M>
+where
+    M: Hash,
+{
     pub(crate) fn hash_key(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
@@ -75,7 +75,24 @@ impl Backend {
     }
 }
 
-impl std::ops::Deref for Backend {
+impl<M> Backend<M> {
+    /// Create a new [Backend] with `weight` 1. The function will try to parse
+    ///  `addr` into a [std::net::SocketAddr].
+    pub fn new_with_meta(addr: &str, meta: M) -> Result<Self> {
+        let addr = addr
+            .parse()
+            .or_err(ErrorType::InternalError, "invalid socket addr")?;
+
+        Ok(Backend {
+            addr: SocketAddr::Inet(addr),
+            weight: 1,
+            metadata: meta,
+        })
+        // TODO: UDS
+    }
+}
+
+impl<M> std::ops::Deref for Backend<M> {
     type Target = SocketAddr;
 
     fn deref(&self) -> &Self::Target {
@@ -83,13 +100,13 @@ impl std::ops::Deref for Backend {
     }
 }
 
-impl std::ops::DerefMut for Backend {
+impl<M> std::ops::DerefMut for Backend<M> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.addr
     }
 }
 
-impl std::net::ToSocketAddrs for Backend {
+impl<M> std::net::ToSocketAddrs for Backend<M> {
     type Iter = std::iter::Once<std::net::SocketAddr>;
 
     fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
@@ -102,18 +119,18 @@ impl std::net::ToSocketAddrs for Backend {
 /// It includes a service discovery method (static or dynamic) to discover all
 /// the available backends as well as an optional health check method to probe the liveness
 /// of each backend.
-pub struct Backends {
-    discovery: Box<dyn ServiceDiscovery + Send + Sync + 'static>,
-    health_check: Option<Arc<dyn health_check::HealthCheck + Send + Sync + 'static>>,
-    backends: ArcSwap<BTreeSet<Backend>>,
+pub struct Backends<M> {
+    discovery: Box<dyn ServiceDiscovery<Metadata = M> + Send + Sync + 'static>,
+    health_check: Option<Arc<dyn health_check::HealthCheck<Metadata = M> + Send + Sync + 'static>>,
+    backends: ArcSwap<BTreeSet<Backend<M>>>,
     health: ArcSwap<HashMap<u64, Health>>,
 }
 
-impl Backends {
+impl<M> Backends<M> {
     /// Create a new [Backends] with the given [ServiceDiscovery] implementation.
     ///
     /// The health check method is by default empty.
-    pub fn new(discovery: Box<dyn ServiceDiscovery + Send + Sync + 'static>) -> Self {
+    pub fn new(discovery: Box<dyn ServiceDiscovery<Metadata = M> + Send + Sync + 'static>) -> Self {
         Self {
             discovery,
             health_check: None,
@@ -125,13 +142,18 @@ impl Backends {
     /// Set the health check method. See [health_check] for the methods provided.
     pub fn set_health_check(
         &mut self,
-        hc: Box<dyn health_check::HealthCheck + Send + Sync + 'static>,
+        hc: Box<dyn health_check::HealthCheck<Metadata = M> + Send + Sync + 'static>,
     ) {
         self.health_check = Some(hc.into())
     }
+}
 
+impl<M> Backends<M>
+where
+    M: PartialEq + Hash,
+{
     /// Return true when the new is different from the current set of backends
-    fn do_update(&self, new_backends: BTreeSet<Backend>, enablement: HashMap<u64, bool>) -> bool {
+    fn do_update(&self, new_backends: BTreeSet<Backend<M>>, enablement: HashMap<u64, bool>) -> bool {
         if (**self.backends.load()) != new_backends {
             let old_health = self.health.load();
             let mut health = HashMap::with_capacity(new_backends.len());
@@ -164,13 +186,28 @@ impl Backends {
         }
     }
 
+    /// Call the service discovery method to update the collection of backends.
+    ///
+    /// Return `true` when the new collection is different from the current set of backends.
+    /// This return value is useful to tell the caller when to rebuild things that are expensive to
+    /// update, such as consistent hashing rings.
+    pub async fn update(&self) -> Result<bool> {
+        let (new_backends, enablement) = self.discovery.discover().await?;
+        Ok(self.do_update(new_backends, enablement))
+    }
+}
+
+impl<M> Backends<M>
+where
+    M: Hash,
+{
     /// Whether a certain [Backend] is ready to serve traffic.
     ///
     /// This function returns true when the backend is both healthy and enabled.
     /// This function returns true when the health check is unset but the backend is enabled.
     /// When the health check is set, this function will return false for the `backend` it
     /// doesn't know.
-    pub fn ready(&self, backend: &Backend) -> bool {
+    pub fn ready(&self, backend: &Backend<M>) -> bool {
         self.health
             .load()
             .get(&backend.hash_key())
@@ -185,28 +222,27 @@ impl Backends {
     /// to stop a backend from accepting traffic when it is still healthy.
     ///
     /// This method is noop when the given backend doesn't exist in the service discovery.
-    pub fn set_enable(&self, backend: &Backend, enabled: bool) {
+    pub fn set_enable(&self, backend: &Backend<M>, enabled: bool) {
         // this should always be Some(_) because health is always populated during update
         if let Some(h) = self.health.load().get(&backend.hash_key()) {
             h.enable(enabled)
         };
     }
+}
 
+impl<M> Backends<M> {
     /// Return the collection of the backends.
-    pub fn get_backend(&self) -> Arc<BTreeSet<Backend>> {
+    pub fn get_backend(&self) -> Arc<BTreeSet<Backend<M>>> {
         self.backends.load_full()
     }
+}
 
-    /// Call the service discovery method to update the collection of backends.
-    ///
-    /// Return `true` when the new collection is different from the current set of backends.
-    /// This return value is useful to tell the caller when to rebuild things that are expensive to
-    /// update, such as consistent hashing rings.
-    pub async fn update(&self) -> Result<bool> {
-        let (new_backends, enablement) = self.discovery.discover().await?;
-        Ok(self.do_update(new_backends, enablement))
-    }
+use core::fmt::Debug;
 
+impl<M> Backends<M>
+where
+    M: Debug + Hash + Send + Clone + Sync + 'static,
+{
     /// Run health check on all backends if it is set.
     ///
     /// When `parallel: true`, all backends are checked in parallel instead of sequentially
@@ -215,9 +251,9 @@ impl Backends {
         use log::{info, warn};
         use pingora_runtime::current_handle;
 
-        async fn check_and_report(
-            backend: &Backend,
-            check: &Arc<dyn HealthCheck + Send + Sync>,
+        async fn check_and_report<M: Debug + Hash>(
+            backend: &Backend<M>,
+            check: &Arc<dyn HealthCheck<Metadata = M> + Send + Sync>,
             health_table: &HashMap<u64, Health>,
         ) {
             let errored = check.check(backend).await.err();
@@ -247,14 +283,14 @@ impl Backends {
                 let check = health_check.clone();
                 let ht = health_table.clone();
                 runtime.spawn(async move {
-                    check_and_report(&backend, &check, &ht).await;
+                    check_and_report::<M>(&backend, &check, &ht).await;
                 })
             });
 
             futures::future::join_all(jobs).await;
         } else {
             for backend in backends.iter() {
-                check_and_report(backend, health_check, &self.health.load()).await;
+                check_and_report::<M>(backend, health_check, &self.health.load()).await;
             }
         }
     }
@@ -265,8 +301,8 @@ impl Backends {
 ///
 /// In order to run service discovery and health check at the designated frequencies, the [LoadBalancer]
 /// needs to be run as a [pingora_core::services::background::BackgroundService].
-pub struct LoadBalancer<S> {
-    backends: Backends,
+pub struct LoadBalancer<S, M> {
+    backends: Backends<M>,
     selector: ArcSwap<S>,
     /// How frequent the health check logic (if set) should run.
     ///
@@ -280,10 +316,11 @@ pub struct LoadBalancer<S> {
     pub parallel_health_check: bool,
 }
 
-impl<'a, S: BackendSelection> LoadBalancer<S>
+impl<'a, S, M> LoadBalancer<S, M>
 where
-    S: BackendSelection + 'static,
-    S::Iter: BackendIter,
+    S: BackendSelection<Metadata = M> + 'static,
+    S::Iter: BackendIter<Metadata = M>,
+    M: Default + Send + Sync + Hash + PartialEq + Ord + Clone + 'static,
 {
     /// Build a [LoadBalancer] with static backends created from the iter.
     ///
@@ -302,9 +339,15 @@ where
             .expect("static should not error");
         Ok(lb)
     }
+}
 
+impl<'a, S, M> LoadBalancer<S, M>
+where
+    S: BackendSelection<Metadata = M> + 'static,
+    S::Iter: BackendIter<Metadata = M>,
+{
     /// Build a [LoadBalancer] with the given [Backends].
-    pub fn from_backends(backends: Backends) -> Self {
+    pub fn from_backends(backends: Backends<M>) -> Self {
         let selector = ArcSwap::new(Arc::new(S::build(&backends.get_backend())));
         LoadBalancer {
             backends,
@@ -314,7 +357,14 @@ where
             parallel_health_check: false,
         }
     }
+}
 
+impl<'a, S, M> LoadBalancer<S, M>
+where
+    S: BackendSelection<Metadata = M> + 'static,
+    S::Iter: BackendIter<Metadata = M>,
+    M: Hash + PartialEq,
+{
     /// Run the service discovery and update the selection algorithm.
     ///
     /// This function will be called every `update_frequency` if this [LoadBalancer] instance
@@ -326,7 +376,14 @@ where
         }
         Ok(())
     }
+}
 
+impl<'a, S, M> LoadBalancer<S, M>
+where
+    S: BackendSelection<Metadata = M> + 'static,
+    S::Iter: BackendIter<Metadata = M>,
+    M: Hash + Clone,
+{
     /// Return the first healthy [Backend] according to the selection algorithm and the
     /// health check results.
     ///
@@ -337,7 +394,7 @@ where
     /// algorithm like Ketama hashing, the search for the next backend is linear and could take
     /// a lot steps.
     // TODO: consider remove `max_iterations` as users have no idea how to set it.
-    pub fn select(&self, key: &[u8], max_iterations: usize) -> Option<Backend> {
+    pub fn select(&self, key: &[u8], max_iterations: usize) -> Option<Backend<M>> {
         self.select_with(key, max_iterations, |_, health| health)
     }
 
@@ -348,9 +405,9 @@ where
     /// backend. The function can do things like ignoring the internal health checks or skipping this backend
     /// because it failed before. The `accept` function is called multiple times iterating over backends
     /// until it returns `true`.
-    pub fn select_with<F>(&self, key: &[u8], max_iterations: usize, accept: F) -> Option<Backend>
+    pub fn select_with<F>(&self, key: &[u8], max_iterations: usize, accept: F) -> Option<Backend<M>>
     where
-        F: Fn(&Backend, bool) -> bool,
+        F: Fn(&Backend<M>, bool) -> bool,
     {
         let selection = self.selector.load();
         let mut iter = UniqueIterator::new(selection.iter(key), max_iterations);
@@ -361,17 +418,24 @@ where
         }
         None
     }
+}
+
+impl<'a, S, M> LoadBalancer<S, M>
+where
+    S: BackendSelection<Metadata = M> + 'static,
+    S::Iter: BackendIter<Metadata = M>,
+{
 
     /// Set the health check method. See [health_check].
     pub fn set_health_check(
         &mut self,
-        hc: Box<dyn health_check::HealthCheck + Send + Sync + 'static>,
+        hc: Box<dyn health_check::HealthCheck<Metadata = M> + Send + Sync + 'static>,
     ) {
         self.backends.set_health_check(hc);
     }
 
     /// Access the [Backends] of this [LoadBalancer]
-    pub fn backends(&self) -> &Backends {
+    pub fn backends(&self) -> &Backends<M> {
         &self.backends
     }
 }

--- a/pingora-load-balancing/src/selection/consistent.rs
+++ b/pingora-load-balancing/src/selection/consistent.rs
@@ -33,7 +33,7 @@ where
     type Iter = OwnedNodeIterator<M>;
     type Metadata = M;
 
-    fn build(backends: &BTreeSet<Backend<M>>) -> Self {
+    fn build(backends: &HashSet<Backend<M>>) -> Self {
         let buckets: Vec<_> = backends
             .iter()
             .filter_map(|b| {
@@ -88,7 +88,7 @@ mod test {
         let b1 = Backend::new_with_meta("1.1.1.1:80", 200u32).unwrap();
         let b2 = Backend::new_with_meta("1.0.0.1:80", 300u32).unwrap();
         let b3 = Backend::new_with_meta("1.0.0.255:80", 400u32).unwrap();
-        let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
+        let backends = HashSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
         let hash = Arc::new(KetamaHashing::build(&backends));
 
         let mut iter = hash.iter(b"test0");
@@ -113,7 +113,7 @@ mod test {
         assert_eq!(iter.next(), Some(&b2));
 
         // remove b3
-        let backends = BTreeSet::from_iter([b1.clone(), b2.clone()]);
+        let backends = HashSet::from_iter([b1.clone(), b2.clone()]);
         let hash = Arc::new(KetamaHashing::build(&backends));
         let mut iter = hash.iter(b"test0");
         assert_eq!(iter.next(), Some(&b2));

--- a/pingora-load-balancing/src/selection/consistent.rs
+++ b/pingora-load-balancing/src/selection/consistent.rs
@@ -85,9 +85,9 @@ mod test {
 
     #[test]
     fn test_ketama() {
-        let b1 = Backend::new("1.1.1.1:80").unwrap();
-        let b2 = Backend::new("1.0.0.1:80").unwrap();
-        let b3 = Backend::new("1.0.0.255:80").unwrap();
+        let b1 = Backend::new_with_meta("1.1.1.1:80", 200u32).unwrap();
+        let b2 = Backend::new_with_meta("1.0.0.1:80", 300u32).unwrap();
+        let b3 = Backend::new_with_meta("1.0.0.255:80", 400u32).unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
         let hash = Arc::new(KetamaHashing::build(&backends));
 

--- a/pingora-load-balancing/src/selection/mod.rs
+++ b/pingora-load-balancing/src/selection/mod.rs
@@ -19,7 +19,7 @@ pub mod consistent;
 pub mod weighted;
 
 use super::Backend;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use weighted::Weighted;
 
@@ -30,7 +30,7 @@ pub trait BackendSelection {
     /// The metadata associated with the Backend
     type Metadata;
     /// The function to create a [BackendSelection] implementation.
-    fn build(backends: &BTreeSet<Backend<Self::Metadata>>) -> Self;
+    fn build(backends: &HashSet<Backend<Self::Metadata>>) -> Self;
     /// Select backends for a given key.
     ///
     /// An [BackendIter] should be returned. The first item in the iter is the first

--- a/pingora-load-balancing/src/selection/weighted.rs
+++ b/pingora-load-balancing/src/selection/weighted.rs
@@ -16,7 +16,7 @@
 
 use super::{Backend, BackendIter, BackendSelection, SelectionAlgorithm};
 use fnv::FnvHasher;
-use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Weighted selection with a given selection algorithm
@@ -36,12 +36,18 @@ where
     type Metadata = M;
     type Iter = WeightedIterator<M, H>;
 
-    fn build(backends: &BTreeSet<Backend<M>>) -> Self {
+    fn build(backends: &HashSet<Backend<M>>) -> Self {
         assert!(
             backends.len() <= u16::MAX as usize,
             "support up to 2^16 backends"
         );
-        let backends = Vec::from_iter(backends.iter().cloned()).into_boxed_slice();
+        let mut backends = Vec::from_iter(backends.iter().cloned()).into_boxed_slice();
+        backends.sort_unstable_by(|a, b| {
+            // Sort "backwards" to ensure that we get "heaviest" backends at
+            // the front of the list
+            b.weight.cmp(&a.weight)
+        });
+
         let mut weighted = Vec::with_capacity(backends.len());
         for (index, b) in backends.iter().enumerate() {
             for _ in 0..b.weight {
@@ -118,40 +124,46 @@ mod test {
         let mut b2 = Backend::new_with_meta("1.0.0.1:80", 2u32).unwrap();
         b2.weight = 10; // 10x than the rest
         let b3 = Backend::new_with_meta("1.0.0.255:80", 3u32).unwrap();
-        let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
+        let backends = HashSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
         let hash: Arc<Weighted<_>> = Arc::new(Weighted::build(&backends));
+
+        // NOTE: We use a HashSet, which has random iteration order. For this reason,
+        // we use the `backends` field instead of the b1/b2/b3 index, as they may have
+        // gotten shuffled randomly while building!
+        //
+        // However, we CAN rely on the fact that `b2` is the "most weighted" option.
 
         // same hash iter over
         let mut iter = hash.iter(b"test");
         // first, should be weighted
         assert_eq!(iter.next(), Some(&b2));
         // fallbacks, should be uniform, not weighted
-        assert_eq!(iter.next(), Some(&b2));
-        assert_eq!(iter.next(), Some(&b2));
-        assert_eq!(iter.next(), Some(&b1));
-        assert_eq!(iter.next(), Some(&b3));
-        assert_eq!(iter.next(), Some(&b2));
-        assert_eq!(iter.next(), Some(&b2));
-        assert_eq!(iter.next(), Some(&b1));
-        assert_eq!(iter.next(), Some(&b2));
-        assert_eq!(iter.next(), Some(&b3));
-        assert_eq!(iter.next(), Some(&b1));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
+        assert_eq!(iter.next(), Some(&hash.backends[2]));
+        assert_eq!(iter.next(), Some(&hash.backends[1]));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
+        assert_eq!(iter.next(), Some(&hash.backends[2]));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
+        assert_eq!(iter.next(), Some(&hash.backends[1]));
+        assert_eq!(iter.next(), Some(&hash.backends[2]));
 
         // different hashes, the first selection should be weighted
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test2");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test3");
-        assert_eq!(iter.next(), Some(&b3));
+        assert_eq!(iter.next(), Some(&hash.backends[1]));
         let mut iter = hash.iter(b"test4");
-        assert_eq!(iter.next(), Some(&b1));
+        assert_eq!(iter.next(), Some(&hash.backends[2]));
         let mut iter = hash.iter(b"test5");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test6");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test7");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
     }
 
     #[test]
@@ -160,34 +172,41 @@ mod test {
         let mut b2 = Backend::new_with_meta("1.0.0.1:80", 2u32).unwrap();
         b2.weight = 8; // 8x than the rest
         let b3 = Backend::new_with_meta("1.0.0.255:80", 3u32).unwrap();
-        let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
+        let backends = HashSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
         let hash: Arc<Weighted<_, RoundRobin>> = Arc::new(Weighted::build(&backends));
+
+        // NOTE: We use a HashSet, which has random iteration order. For this reason,
+        // we use the `backends` field instead of the b1/b2/b3 index, as they may have
+        // gotten shuffled randomly while building!
+        //
+        // However, we CAN rely on the fact that `b2` is the "most weighted" option.
 
         // same hash iter over
         let mut iter = hash.iter(b"test");
+
         // first, should be weighted
         assert_eq!(iter.next(), Some(&b2));
         // fallbacks, should be round robin
-        assert_eq!(iter.next(), Some(&b3));
-        assert_eq!(iter.next(), Some(&b1));
-        assert_eq!(iter.next(), Some(&b2));
-        assert_eq!(iter.next(), Some(&b3));
+        assert_eq!(iter.next(), Some(&hash.backends[1]));
+        assert_eq!(iter.next(), Some(&hash.backends[2]));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
+        assert_eq!(iter.next(), Some(&hash.backends[1]));
 
         // round robin, ignoring the hash key
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b3));
+        assert_eq!(iter.next(), Some(&hash.backends[1]));
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b1));
+        assert_eq!(iter.next(), Some(&hash.backends[2]));
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
         let mut iter = hash.iter(b"test1");
-        assert_eq!(iter.next(), Some(&b2));
+        assert_eq!(iter.next(), Some(&hash.backends[0]));
     }
 
     #[test]
@@ -196,7 +215,7 @@ mod test {
         let mut b2 = Backend::new_with_meta("1.0.0.1:80", 100u32).unwrap();
         b2.weight = 8; // 8x than the rest
         let b3 = Backend::new_with_meta("1.0.0.255:80", 100u32).unwrap();
-        let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
+        let backends = HashSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
         let hash: Arc<Weighted<_, Random>> = Arc::new(Weighted::build(&backends));
 
         let mut count = HashMap::new();

--- a/pingora-load-balancing/src/selection/weighted.rs
+++ b/pingora-load-balancing/src/selection/weighted.rs
@@ -192,10 +192,10 @@ mod test {
 
     #[test]
     fn test_random() {
-        let b1 = Backend::new("1.1.1.1:80").unwrap();
-        let mut b2 = Backend::new("1.0.0.1:80").unwrap();
+        let b1 = Backend::new_with_meta("1.1.1.1:80", 100u32).unwrap();
+        let mut b2 = Backend::new_with_meta("1.0.0.1:80", 100u32).unwrap();
         b2.weight = 8; // 8x than the rest
-        let b3 = Backend::new("1.0.0.255:80").unwrap();
+        let b3 = Backend::new_with_meta("1.0.0.255:80", 100u32).unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
         let hash: Arc<Weighted<_, Random>> = Arc::new(Weighted::build(&backends));
 

--- a/pingora-load-balancing/src/selection/weighted.rs
+++ b/pingora-load-balancing/src/selection/weighted.rs
@@ -114,12 +114,12 @@ mod test {
 
     #[test]
     fn test_fnv() {
-        let b1 = Backend::new("1.1.1.1:80").unwrap();
-        let mut b2 = Backend::new("1.0.0.1:80").unwrap();
+        let b1 = Backend::new_with_meta("1.1.1.1:80", 1u32).unwrap();
+        let mut b2 = Backend::new_with_meta("1.0.0.1:80", 2u32).unwrap();
         b2.weight = 10; // 10x than the rest
-        let b3 = Backend::new("1.0.0.255:80").unwrap();
+        let b3 = Backend::new_with_meta("1.0.0.255:80", 3u32).unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash: Arc<Weighted> = Arc::new(Weighted::build(&backends));
+        let hash: Arc<Weighted<_>> = Arc::new(Weighted::build(&backends));
 
         // same hash iter over
         let mut iter = hash.iter(b"test");
@@ -156,12 +156,12 @@ mod test {
 
     #[test]
     fn test_round_robin() {
-        let b1 = Backend::new("1.1.1.1:80").unwrap();
-        let mut b2 = Backend::new("1.0.0.1:80").unwrap();
+        let b1 = Backend::new_with_meta("1.1.1.1:80", 1u32).unwrap();
+        let mut b2 = Backend::new_with_meta("1.0.0.1:80", 2u32).unwrap();
         b2.weight = 8; // 8x than the rest
-        let b3 = Backend::new("1.0.0.255:80").unwrap();
+        let b3 = Backend::new_with_meta("1.0.0.255:80", 3u32).unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash: Arc<Weighted<RoundRobin>> = Arc::new(Weighted::build(&backends));
+        let hash: Arc<Weighted<_, RoundRobin>> = Arc::new(Weighted::build(&backends));
 
         // same hash iter over
         let mut iter = hash.iter(b"test");
@@ -197,7 +197,7 @@ mod test {
         b2.weight = 8; // 8x than the rest
         let b3 = Backend::new("1.0.0.255:80").unwrap();
         let backends = BTreeSet::from_iter([b1.clone(), b2.clone(), b3.clone()]);
-        let hash: Arc<Weighted<Random>> = Arc::new(Weighted::build(&backends));
+        let hash: Arc<Weighted<_, Random>> = Arc::new(Weighted::build(&backends));
 
         let mut count = HashMap::new();
         count.insert(b1.clone(), 0);

--- a/pingora-proxy/examples/load_balancer.rs
+++ b/pingora-proxy/examples/load_balancer.rs
@@ -68,7 +68,8 @@ fn main() {
 
     // 127.0.0.1:343" is just a bad server
     let mut upstreams =
-        LoadBalancer::try_from_iter_default_meta(["1.1.1.1:443", "1.0.0.1:443", "127.0.0.1:343"]).unwrap();
+        LoadBalancer::try_from_iter_default_meta(["1.1.1.1:443", "1.0.0.1:443", "127.0.0.1:343"])
+            .unwrap();
 
     // We add health check in the background so that the bad server is never selected.
     let hc = health_check::TcpHealthCheck::new();

--- a/pingora-proxy/examples/load_balancer.rs
+++ b/pingora-proxy/examples/load_balancer.rs
@@ -25,7 +25,7 @@ use pingora_core::Result;
 use pingora_load_balancing::{health_check, selection::RoundRobin, LoadBalancer};
 use pingora_proxy::{ProxyHttp, Session};
 
-pub struct LB(Arc<LoadBalancer<RoundRobin>>);
+pub struct LB(Arc<LoadBalancer<RoundRobin<()>, ()>>);
 
 #[async_trait]
 impl ProxyHttp for LB {
@@ -68,7 +68,7 @@ fn main() {
 
     // 127.0.0.1:343" is just a bad server
     let mut upstreams =
-        LoadBalancer::try_from_iter(["1.1.1.1:443", "1.0.0.1:443", "127.0.0.1:343"]).unwrap();
+        LoadBalancer::try_from_iter_default_meta(["1.1.1.1:443", "1.0.0.1:443", "127.0.0.1:343"]).unwrap();
 
     // We add health check in the background so that the bad server is never selected.
     let hc = health_check::TcpHealthCheck::new();


### PR DESCRIPTION
This is part of an attempt to address https://github.com/cloudflare/pingora/issues/276#issuecomment-2166553791, by adding a metadata field that can be any type.

I don't think this is ready to merge, but I'm open to some feedback on the approach, so far.

Open questions/comments:

* I don't *love* what this has done to the signatures of a lot of the types
* I need to take this for a test in `river`, to see if the API allows me to do what I want:
    * Associate things like TLS_SNI information, obtained through discovery
* It's possible this interface might allow us to remove some existing "glue" parts, like `HttpHealthCheck->peer_template`, in favor of actually having the full information needed per `Backend`.
* This is almost certainly a breaking change, which maybe could happen in 0.3 soon? CC #298.

I'll let you know how it goes!