### PR TITLE
Add error log when attempting to upgrade on not-Linux

### DIFF
--- a/pingora-core/src/server/transfer_fd/mod.rs
+++ b/pingora-core/src/server/transfer_fd/mod.rs
@@ -179,6 +179,7 @@ pub fn get_fds_from<P>(_path: &P, _payload: &mut [u8]) -> Result<(Vec<RawFd>, us
 where
     P: ?Sized + NixPath + std::fmt::Display,
 {
+    log::error!("Upgrade is not currently supported outside of Linux platforms");
     Err(Errno::ECONNREFUSED)
 }
 


### PR DESCRIPTION
I was attempting to test upgrades on MacOS, and was a bit confused at the ECONNREFUSED error.

Having this log would help others avoiding troubleshooting this until it is supported.