### PR TITLE
docs: fix doc comment for request_summary

### DIFF
--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -316,7 +316,7 @@ impl HttpSession {
             .map_or(b"", |h| h.as_bytes())
     }
 
-    /// Return a string `$METHOD $PATH $HOST`. Mostly for logging and debug purpose
+    /// Return a string `$METHOD $PATH, Host: $HOST`. Mostly for logging and debug purpose
     pub fn request_summary(&self) -> String {
         format!(
             "{} {}, Host: {}",

--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -344,7 +344,7 @@ impl HttpSession {
         Ok(end_stream)
     }
 
-    /// Return a string `$METHOD $PATH $HOST`. Mostly for logging and debug purpose
+    /// Return a string `$METHOD $PATH, Host: $HOST`. Mostly for logging and debug purpose
     pub fn request_summary(&self) -> String {
         format!(
             "{} {}, Host: {}",


### PR DESCRIPTION
The crate documentation at
* https://docs.rs/pingora/latest/pingora/protocols/http/v1/server/struct.HttpSession.html#method.request_summary
* https://docs.rs/pingora/latest/pingora/protocols/http/v2/server/struct.HttpSession.html#method.request_summary

doesn't actually reflect the correct format string. I got surprised by the trailing comma on $PATH when using this