### PR TITLE
Add basic windows support

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -35,7 +35,6 @@ http = { workspace = true }
 log = { workspace = true }
 h2 = { workspace = true }
 lru = { workspace = true }
-nix = "~0.24.3"
 clap = { version = "3.2.25", features = ["derive"] }
 once_cell = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -46,7 +45,6 @@ libc = "0.2.70"
 chrono = { version = "~0.4.31", features = ["alloc"], default-features = false }
 thread_local = "1.0"
 prometheus = "0.13"
-daemonize = "0.5.0"
 sentry = { version = "0.26", features = [
     "backtrace",
     "contexts",
@@ -69,13 +67,22 @@ tokio-test = "0.4"
 zstd = "0"
 httpdate = "1"
 
+[target.'cfg(unix)'.dependencies]
+daemonize = "0.5.0"
+nix = "~0.24.3"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59.0", features = ["Win32_Networking_WinSock"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+hyperlocal = "0.8"
+jemallocator = "0.5"
+
 [dev-dependencies]
 matches = "0.1"
 env_logger = "0.9"
 reqwest = { version = "0.11", features = ["rustls"], default-features = false }
-hyperlocal = "0.8"
 hyper = "0.14"
-jemallocator = "0.5"
 
 [features]
 default = ["openssl"]

--- a/pingora-core/src/connectors/http/v2.rs
+++ b/pingora-core/src/connectors/http/v2.rs
@@ -16,7 +16,7 @@ use super::HttpSession;
 use crate::connectors::{ConnectorOptions, TransportConnector};
 use crate::protocols::http::v1::client::HttpSession as Http1Session;
 use crate::protocols::http::v2::client::{drive_connection, Http2Session};
-use crate::protocols::{Digest, Stream};
+use crate::protocols::{Digest, Stream, UniqueIDType};
 use crate::upstreams::peer::{Peer, ALPN};
 
 use bytes::Bytes;
@@ -47,7 +47,7 @@ pub(crate) struct ConnectionRefInner {
     connection_stub: Stub,
     closed: watch::Receiver<bool>,
     ping_timeout_occurred: Arc<AtomicBool>,
-    id: i32,
+    id: UniqueIDType,
     // max concurrent streams this connection is allowed to create
     max_streams: usize,
     // how many concurrent streams already active
@@ -69,7 +69,7 @@ impl ConnectionRef {
         send_req: SendRequest<Bytes>,
         closed: watch::Receiver<bool>,
         ping_timeout_occurred: Arc<AtomicBool>,
-        id: i32,
+        id: UniqueIDType,
         max_streams: usize,
         digest: Digest,
     ) -> Self {
@@ -98,7 +98,7 @@ impl ConnectionRef {
         self.0.current_streams.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub fn id(&self) -> i32 {
+    pub fn id(&self) -> UniqueIDType {
         self.0.id
     }
 
@@ -196,7 +196,7 @@ impl InUsePool {
 
     // release a h2_stream, this functional will cause an ConnectionRef to be returned (if exist)
     // the caller should update the ref and then decide where to put it (in use pool or idle)
-    fn release(&self, reuse_hash: u64, id: i32) -> Option<ConnectionRef> {
+    fn release(&self, reuse_hash: u64, id: UniqueIDType) -> Option<ConnectionRef> {
         let pools = self.pools.read();
         if let Some(pool) = pools.get(&reuse_hash) {
             pool.remove(id)

--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -17,10 +17,15 @@ use log::debug;
 use pingora_error::{Context, Error, ErrorType::*, OrErr, Result};
 use rand::seq::SliceRandom;
 use std::net::SocketAddr as InetSocketAddr;
+#[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawSocket;
 
+#[cfg(unix)]
+use crate::protocols::l4::ext::connect_uds;
 use crate::protocols::l4::ext::{
-    connect_uds, connect_with as tcp_connect, set_dscp, set_recv_buf, set_tcp_fastopen_connect,
+    connect_with as tcp_connect, set_dscp, set_recv_buf, set_tcp_fastopen_connect,
 };
 use crate::protocols::l4::socket::SocketAddr;
 use crate::protocols::l4::stream::Stream;
@@ -39,9 +44,12 @@ where
     P: Peer + Send + Sync,
 {
     if peer.get_proxy().is_some() {
+        #[cfg(unix)]
         return proxy_connect(peer)
             .await
             .err_context(|| format!("Fail to establish CONNECT proxy: {}", peer));
+        #[cfg(windows)]
+        panic!("peer proxy not supported on windows")
     }
     let peer_addr = peer.address();
     let mut stream: Stream =
@@ -51,16 +59,21 @@ where
             match peer_addr {
                 SocketAddr::Inet(addr) => {
                     let connect_future = tcp_connect(addr, bind_to.as_ref(), |socket| {
+                        #[cfg(unix)]
+                        let raw = socket.as_raw_fd();
+                        #[cfg(windows)]
+                        let raw = socket.as_raw_socket();
+
                         if peer.tcp_fast_open() {
-                            set_tcp_fastopen_connect(socket.as_raw_fd())?;
+                            set_tcp_fastopen_connect(raw)?;
                         }
                         if let Some(recv_buf) = peer.tcp_recv_buf() {
                             debug!("Setting recv buf size");
-                            set_recv_buf(socket.as_raw_fd(), recv_buf)?;
+                            set_recv_buf(raw, recv_buf)?;
                         }
                         if let Some(dscp) = peer.dscp() {
                             debug!("Setting dscp");
-                            set_dscp(socket.as_raw_fd(), dscp)?;
+                            set_dscp(raw, dscp)?;
                         }
                         Ok(())
                     });
@@ -86,6 +99,7 @@ where
                         }
                     }
                 }
+                #[cfg(unix)]
                 SocketAddr::Unix(addr) => {
                     let connect_future = connect_uds(
                         addr.as_pathname()
@@ -128,7 +142,10 @@ where
     }
     stream.set_nodelay()?;
 
+    #[cfg(unix)]
     let digest = SocketDigest::from_raw_fd(stream.as_raw_fd());
+    #[cfg(windows)]
+    let digest = SocketDigest::from_raw_socket(stream.as_raw_socket());
     digest
         .peer_addr
         .set(Some(peer_addr.clone()))
@@ -164,12 +181,14 @@ pub(crate) fn bind_to_random<P: Peer>(
             InetSocketAddr::V4(_) => bind_to_ips(v4_list),
             InetSocketAddr::V6(_) => bind_to_ips(v6_list),
         },
+        #[cfg(unix)]
         SocketAddr::Unix(_) => None,
     }
 }
 
 use crate::protocols::raw_connect;
 
+#[cfg(unix)]
 async fn proxy_connect<P: Peer>(peer: &P) -> Result<Stream> {
     // safe to unwrap
     let proxy = peer.get_proxy().unwrap();
@@ -217,6 +236,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use tokio::io::AsyncWriteExt;
+    #[cfg(unix)]
     use tokio::net::UnixListener;
 
     #[tokio::test]
@@ -285,6 +305,7 @@ mod tests {
         assert!(new_session.is_ok());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_connect_proxy_fail() {
         let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
@@ -302,9 +323,11 @@ mod tests {
         assert!(!e.retry());
     }
 
+    #[cfg(unix)]
     const MOCK_UDS_PATH: &str = "/tmp/test_unix_connect_proxy.sock";
 
     // one-off mock server
+    #[cfg(unix)]
     async fn mock_connect_server() {
         let _ = std::fs::remove_file(MOCK_UDS_PATH);
         let listener = UnixListener::bind(MOCK_UDS_PATH).unwrap();
@@ -316,6 +339,7 @@ mod tests {
         let _ = std::fs::remove_file(MOCK_UDS_PATH);
     }
 
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_connect_proxy_work() {
         tokio::spawn(async {
@@ -336,10 +360,12 @@ mod tests {
         assert!(new_session.is_ok());
     }
 
+    #[cfg(unix)]
     const MOCK_BAD_UDS_PATH: &str = "/tmp/test_unix_bad_connect_proxy.sock";
 
     // one-off mock bad proxy
     // closes connection upon accepting
+    #[cfg(unix)]
     async fn mock_connect_bad_server() {
         let _ = std::fs::remove_file(MOCK_BAD_UDS_PATH);
         let listener = UnixListener::bind(MOCK_BAD_UDS_PATH).unwrap();
@@ -350,6 +376,7 @@ mod tests {
         let _ = std::fs::remove_file(MOCK_BAD_UDS_PATH);
     }
 
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_connect_proxy_conn_closed() {
         tokio::spawn(async {

--- a/pingora-core/src/protocols/http/v1/client.rs
+++ b/pingora-core/src/protocols/http/v1/client.rs
@@ -28,7 +28,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use super::body::{BodyReader, BodyWriter};
 use super::common::*;
 use crate::protocols::http::HttpTask;
-use crate::protocols::{Digest, SocketAddr, Stream, UniqueID};
+use crate::protocols::{Digest, SocketAddr, Stream, UniqueID, UniqueIDType};
 use crate::utils::{BufRef, KVRef};
 
 /// The HTTP 1.x client session
@@ -717,7 +717,7 @@ pub(crate) fn http_req_header_to_wire(req: &RequestHeader) -> Option<BytesMut> {
 }
 
 impl UniqueID for HttpSession {
-    fn id(&self) -> i32 {
+    fn id(&self) -> UniqueIDType {
         self.underlying_stream.id()
     }
 }

--- a/pingora-core/src/protocols/http/v2/client.rs
+++ b/pingora-core/src/protocols/http/v2/client.rs
@@ -30,7 +30,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::watch;
 
 use crate::connectors::http::v2::ConnectionRef;
-use crate::protocols::{Digest, SocketAddr};
+use crate::protocols::{Digest, SocketAddr, UniqueIDType};
 
 pub const PING_TIMEDOUT: ErrorType = ErrorType::new("PingTimedout");
 
@@ -336,7 +336,7 @@ impl Http2Session {
     }
 
     /// the FD of the underlying connection
-    pub fn fd(&self) -> i32 {
+    pub fn fd(&self) -> UniqueIDType {
         self.conn.id()
     }
 
@@ -415,7 +415,7 @@ use tokio::sync::oneshot;
 
 pub async fn drive_connection<S>(
     mut c: client::Connection<S>,
-    id: i32,
+    id: UniqueIDType,
     closed: watch::Sender<bool>,
     ping_interval: Option<Duration>,
     ping_timeout_occurred: Arc<AtomicBool>,
@@ -469,7 +469,7 @@ async fn do_ping_pong(
     interval: Duration,
     tx: oneshot::Sender<()>,
     dropped: Arc<AtomicBool>,
-    id: i32,
+    id: UniqueIDType,
 ) {
     // delay before sending the first ping, no need to race with the first request
     tokio::time::sleep(interval).await;

--- a/pingora-core/src/protocols/l4/ext.rs
+++ b/pingora-core/src/protocols/l4/ext.rs
@@ -16,6 +16,7 @@
 
 #![allow(non_camel_case_types)]
 
+#[cfg(unix)]
 use libc::socklen_t;
 #[cfg(target_os = "linux")]
 use libc::{c_int, c_ulonglong, c_void};
@@ -23,9 +24,14 @@ use pingora_error::{Error, ErrorType::*, OrErr, Result};
 use std::io::{self, ErrorKind};
 use std::mem;
 use std::net::SocketAddr;
+#[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::time::Duration;
-use tokio::net::{TcpSocket, TcpStream, UnixStream};
+#[cfg(unix)]
+use tokio::net::UnixStream;
+use tokio::net::{TcpSocket, TcpStream};
 
 /// The (copy of) the kernel struct tcp_info returns
 #[repr(C)]
@@ -96,8 +102,13 @@ impl TCP_INFO {
     }
 
     /// Return the size of [`TCP_INFO`]
+    #[cfg(unix)]
     pub fn len() -> socklen_t {
         mem::size_of::<Self>() as socklen_t
+    }
+    #[cfg(windows)]
+    pub fn len() -> usize {
+        mem::size_of::<Self>()
     }
 }
 
@@ -165,7 +176,7 @@ fn ip_bind_addr_no_port(fd: RawFd, val: bool) -> io::Result<()> {
     set_opt(fd, libc::IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, val as c_int)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn ip_bind_addr_no_port(_fd: RawFd, _val: bool) -> io::Result<()> {
     Ok(())
 }
@@ -208,8 +219,13 @@ fn set_keepalive(fd: RawFd, ka: &TcpKeepalive) -> io::Result<()> {
     set_so_keepalive_count(fd, ka.count)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn set_keepalive(_fd: RawFd, _ka: &TcpKeepalive) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn set_keepalive(_sock: RawSocket, _ka: &TcpKeepalive) -> io::Result<()> {
     Ok(())
 }
 
@@ -219,8 +235,13 @@ pub fn get_tcp_info(fd: RawFd) -> io::Result<TCP_INFO> {
     get_opt_sized(fd, libc::IPPROTO_TCP, libc::TCP_INFO)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn get_tcp_info(_fd: RawFd) -> io::Result<TCP_INFO> {
+    Ok(unsafe { TCP_INFO::new() })
+}
+
+#[cfg(windows)]
+pub fn get_tcp_info(_sock: RawSocket) -> io::Result<TCP_INFO> {
     Ok(unsafe { TCP_INFO::new() })
 }
 
@@ -231,8 +252,13 @@ pub fn set_recv_buf(fd: RawFd, val: usize) -> Result<()> {
         .or_err(ConnectError, "failed to set SO_RCVBUF")
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn set_recv_buf(_fd: RawFd, _: usize) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn set_recv_buf(_sock: RawSocket, _: usize) -> Result<()> {
     Ok(())
 }
 
@@ -241,8 +267,13 @@ pub fn get_recv_buf(fd: RawFd) -> io::Result<usize> {
     get_opt_sized::<c_int>(fd, libc::SOL_SOCKET, libc::SO_RCVBUF).map(|v| v as usize)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn get_recv_buf(_fd: RawFd) -> io::Result<usize> {
+    Ok(0)
+}
+
+#[cfg(windows)]
+pub fn get_recv_buf(_sock: RawSocket) -> io::Result<usize> {
     Ok(0)
 }
 
@@ -258,8 +289,13 @@ pub fn set_tcp_fastopen_connect(fd: RawFd) -> Result<()> {
     .or_err(ConnectError, "failed to set TCP_FASTOPEN_CONNECT")
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn set_tcp_fastopen_connect(_fd: RawFd) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn set_tcp_fastopen_connect(_sock: RawSocket) -> Result<()> {
     Ok(())
 }
 
@@ -270,11 +306,15 @@ pub fn set_tcp_fastopen_backlog(fd: RawFd, backlog: usize) -> Result<()> {
         .or_err(ConnectError, "failed to set TCP_FASTOPEN")
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn set_tcp_fastopen_backlog(_fd: RawFd, _backlog: usize) -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
+pub fn set_tcp_fastopen_backlog(_sock: RawSocket, _backlog: usize) -> Result<()> {
+    Ok(())
+}
 #[cfg(target_os = "linux")]
 pub fn set_dscp(fd: RawFd, value: u8) -> Result<()> {
     use super::socket::SocketAddr;
@@ -295,8 +335,13 @@ pub fn set_dscp(fd: RawFd, value: u8) -> Result<()> {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn set_dscp(_fd: RawFd, _value: u8) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn set_dscp(_sock: RawSocket, _value: u8) -> Result<()> {
     Ok(())
 }
 
@@ -305,7 +350,7 @@ pub fn get_socket_cookie(fd: RawFd) -> io::Result<u64> {
     get_opt_sized::<c_ulonglong>(fd, libc::SOL_SOCKET, libc::SO_COOKIE)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(unix, not(target_os = "linux")))]
 pub fn get_socket_cookie(_fd: RawFd) -> io::Result<u64> {
     Ok(0) // SO_COOKIE is a Linux concept
 }
@@ -327,7 +372,8 @@ pub(crate) async fn connect_with<F: FnOnce(&TcpSocket) -> Result<()>>(
     }
     .or_err(SocketError, "failed to create socket")?;
 
-    if cfg!(target_os = "linux") {
+    #[cfg(target_os = "linux")]
+    {
         ip_bind_addr_no_port(socket.as_raw_fd(), true)
             .or_err(SocketError, "failed to set socket opts")?;
 
@@ -337,6 +383,12 @@ pub(crate) async fn connect_with<F: FnOnce(&TcpSocket) -> Result<()>>(
                 .or_err_with(BindError, || format!("failed to bind to socket {}", *baddr))?;
         };
     }
+    #[cfg(windows)]
+    if let Some(baddr) = bind_to {
+        socket
+            .bind(*baddr)
+            .or_err_with(BindError, || format!("failed to bind to socket {}", *baddr))?;
+    };
     // TODO: add support for bind on other platforms
 
     set_socket(&socket)?;
@@ -355,6 +407,7 @@ pub async fn connect(addr: &SocketAddr, bind_to: Option<&SocketAddr>) -> Result<
 }
 
 /// connect() to the given Unix domain socket
+#[cfg(unix)]
 pub async fn connect_uds(path: &std::path::Path) -> Result<UnixStream> {
     UnixStream::connect(path)
         .await
@@ -396,9 +449,12 @@ impl std::fmt::Display for TcpKeepalive {
 
 /// Apply the given TCP keepalive settings to the given connection
 pub fn set_tcp_keepalive(stream: &TcpStream, ka: &TcpKeepalive) -> Result<()> {
-    let fd = stream.as_raw_fd();
+    #[cfg(unix)]
+    let raw = stream.as_raw_fd();
+    #[cfg(windows)]
+    let raw = stream.as_raw_socket();
     // TODO: check localhost or if keepalive is already set
-    set_keepalive(fd, ka).or_err(ConnectError, "failed to set keepalive")
+    set_keepalive(raw, ka).or_err(ConnectError, "failed to set keepalive")
 }
 
 #[cfg(test)]
@@ -409,7 +465,10 @@ mod test {
     fn test_set_recv_buf() {
         use tokio::net::TcpSocket;
         let socket = TcpSocket::new_v4().unwrap();
+        #[cfg(unix)]
         set_recv_buf(socket.as_raw_fd(), 102400).unwrap();
+        #[cfg(windows)]
+        set_recv_buf(socket.as_raw_socket(), 102400).unwrap();
 
         #[cfg(target_os = "linux")]
         {

--- a/pingora-core/src/protocols/ssl/mod.rs
+++ b/pingora-core/src/protocols/ssl/mod.rs
@@ -93,6 +93,8 @@ impl<T> SslStream<T> {
 
 use std::ops::{Deref, DerefMut};
 
+use super::UniqueIDType;
+
 impl<T> Deref for SslStream<T> {
     type Target = InnerSsl<T>;
 
@@ -162,7 +164,7 @@ impl<T> UniqueID for SslStream<T>
 where
     T: UniqueID,
 {
-    fn id(&self) -> i32 {
+    fn id(&self) -> UniqueIDType {
         self.ssl.get_ref().id()
     }
 }

--- a/pingora-core/src/protocols/windows.rs
+++ b/pingora-core/src/protocols/windows.rs
@@ -1,0 +1,115 @@
+//! Windows specific functionality for calling the WinSock c api
+//!
+//! Implementations here are based on the implementation in the std library
+//! https://github.com/rust-lang/rust/blob/84ac80f/library/std/src/sys_common/net.rs
+//! https://github.com/rust-lang/rust/blob/84ac80f/library/std/src/sys/pal/windows/net.rs
+
+use std::os::windows::io::RawSocket;
+use std::{io, mem, net::SocketAddr};
+
+use windows_sys::Win32::Networking::WinSock::{
+    getpeername, getsockname, AF_INET, AF_INET6, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_STORAGE,
+    SOCKET,
+};
+
+pub(crate) fn peer_addr(raw_sock: RawSocket) -> io::Result<SocketAddr> {
+    let mut storage = unsafe { mem::zeroed::<SOCKADDR_STORAGE>() };
+    let mut addrlen = mem::size_of_val(&storage) as i32;
+
+    unsafe {
+        let res = getpeername(
+            raw_sock as SOCKET,
+            core::ptr::addr_of_mut!(storage) as *mut _,
+            &mut addrlen,
+        );
+        if res != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    sockaddr_to_addr(&storage, addrlen as usize)
+}
+pub(crate) fn local_addr(raw_sock: RawSocket) -> io::Result<SocketAddr> {
+    let mut storage = unsafe { mem::zeroed::<SOCKADDR_STORAGE>() };
+    let mut addrlen = mem::size_of_val(&storage) as i32;
+
+    unsafe {
+        let res = getsockname(
+            raw_sock as libc::SOCKET,
+            core::ptr::addr_of_mut!(storage) as *mut _,
+            &mut addrlen,
+        );
+        if res != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    sockaddr_to_addr(&storage, addrlen as usize)
+}
+
+fn sockaddr_to_addr(storage: &SOCKADDR_STORAGE, len: usize) -> io::Result<SocketAddr> {
+    match storage.ss_family {
+        AF_INET => {
+            assert!(len >= mem::size_of::<SOCKADDR_IN>());
+            Ok(SocketAddr::from(unsafe {
+                let sockaddr = *(storage as *const _ as *const SOCKADDR_IN);
+                (
+                    sockaddr.sin_addr.S_un.S_addr.to_ne_bytes(),
+                    sockaddr.sin_port.to_be(),
+                )
+            }))
+        }
+        AF_INET6 => {
+            assert!(len >= mem::size_of::<SOCKADDR_IN6>());
+            Ok(SocketAddr::from(unsafe {
+                let sockaddr = *(storage as *const _ as *const SOCKADDR_IN6);
+                (sockaddr.sin6_addr.u.Byte, sockaddr.sin6_port.to_be())
+            }))
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid argument",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::windows::io::AsRawSocket;
+
+    use crate::protocols::l4::{listener::Listener, stream::Stream};
+
+    use super::*;
+
+    async fn assert_listener_and_stream(addr: &str) {
+        let tokio_listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+
+        let listener_local_addr = tokio_listener.local_addr().unwrap();
+
+        let tokio_stream = tokio::net::TcpStream::connect(listener_local_addr)
+            .await
+            .unwrap();
+
+        let stream_local_addr = tokio_stream.local_addr().unwrap();
+        let stream_peer_addr = tokio_stream.peer_addr().unwrap();
+
+        let stream: Stream = tokio_stream.into();
+        let listener: Listener = tokio_listener.into();
+
+        let raw_sock = listener.as_raw_socket();
+        assert_eq!(listener_local_addr, local_addr(raw_sock).unwrap());
+
+        let raw_sock = stream.as_raw_socket();
+        assert_eq!(stream_peer_addr, peer_addr(raw_sock).unwrap());
+        assert_eq!(stream_local_addr, local_addr(raw_sock).unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_v4_addrs_from_raw_socket() {
+        assert_listener_and_stream("127.0.0.1:0").await
+    }
+    #[tokio::test]
+    async fn get_v6_addrs_from_raw_socket() {
+        assert_listener_and_stream("[::1]:0").await
+    }
+}

--- a/pingora-core/src/server/daemon.rs
+++ b/pingora-core/src/server/daemon.rs
@@ -54,6 +54,7 @@ unsafe fn gid_for_username(name: &CString) -> Option<libc::gid_t> {
 }
 
 /// Start a server instance as a daemon.
+#[cfg(unix)]
 pub fn daemonize(conf: &ServerConf) {
     // TODO: customize working dir
 

--- a/pingora-core/src/services/background.rs
+++ b/pingora-core/src/services/background.rs
@@ -23,7 +23,9 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use super::Service;
-use crate::server::{ListenFds, ShutdownWatch};
+#[cfg(unix)]
+use crate::server::ListenFds;
+use crate::server::ShutdownWatch;
 
 /// The background service interface
 #[async_trait]
@@ -65,7 +67,11 @@ impl<A> Service for GenBackgroundService<A>
 where
     A: BackgroundService + Send + Sync + 'static,
 {
-    async fn start_service(&mut self, _fds: Option<ListenFds>, shutdown: ShutdownWatch) {
+    async fn start_service(
+        &mut self,
+        #[cfg(unix)] _fds: Option<ListenFds>,
+        shutdown: ShutdownWatch,
+    ) {
         self.task.start(shutdown).await;
     }
 

--- a/pingora-core/src/services/mod.rs
+++ b/pingora-core/src/services/mod.rs
@@ -23,7 +23,9 @@
 
 use async_trait::async_trait;
 
-use crate::server::{ListenFds, ShutdownWatch};
+#[cfg(unix)]
+use crate::server::ListenFds;
+use crate::server::ShutdownWatch;
 
 pub mod background;
 pub mod listening;
@@ -39,7 +41,11 @@ pub trait Service: Sync + Send {
     /// the collection, the service should create its own listening sockets and then put them into
     /// the collection in order for them to be passed to the next server.
     /// - `shutdown`: the shutdown signal this server would receive.
-    async fn start_service(&mut self, fds: Option<ListenFds>, mut shutdown: ShutdownWatch);
+    async fn start_service(
+        &mut self,
+        #[cfg(unix)] fds: Option<ListenFds>,
+        mut shutdown: ShutdownWatch,
+    );
 
     /// The name of the service, just for logging and naming the threads assigned to this service
     ///

--- a/pingora-core/tests/test_basic.rs
+++ b/pingora-core/tests/test_basic.rs
@@ -15,6 +15,7 @@
 mod utils;
 
 use hyper::Client;
+#[cfg(unix)]
 use hyperlocal::{UnixClientExt, Uri};
 use utils::init;
 
@@ -49,6 +50,7 @@ async fn test_https_http2() {
     assert_eq!(res.version(), reqwest::Version::HTTP_11);
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn test_uds() {
     init();

--- a/pingora-core/tests/utils/mod.rs
+++ b/pingora-core/tests/utils/mod.rs
@@ -78,6 +78,7 @@ fn entry_point(opt: Option<Opt>) {
     my_server.bootstrap();
 
     let mut listeners = Listeners::tcp("0.0.0.0:6145");
+    #[cfg(unix)]
     listeners.add_uds("/tmp/echo.sock", None);
 
     let mut tls_settings =

--- a/pingora-pool/src/connection.rs
+++ b/pingora-pool/src/connection.rs
@@ -27,7 +27,10 @@ use tokio::sync::{oneshot, watch, Notify, OwnedMutexGuard};
 use super::lru::Lru;
 
 type GroupKey = u64;
+#[cfg(unix)]
 type ID = i32;
+#[cfg(windows)]
+type ID = usize;
 
 /// the metadata of a connection
 #[derive(Clone, Debug)]

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -34,6 +34,9 @@ once_cell = { workspace = true }
 clap = { version = "3.2.25", features = ["derive"] }
 regex = "1"
 
+[target.'cfg(unix)'.dev-dependencies]
+hyperlocal = "0.8"
+
 [dev-dependencies]
 reqwest = { version = "0.11", features = [
     "gzip",
@@ -41,7 +44,6 @@ reqwest = { version = "0.11", features = [
 ], default-features = false }
 tokio-test = "0.4"
 env_logger = "0.9"
-hyperlocal = "0.8"
 hyper = "0.14"
 tokio-tungstenite = "0.20.1"
 pingora-load-balancing = { version = "0.3.0", path = "../pingora-load-balancing" }

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -116,13 +116,18 @@ impl<SV> HttpProxy<SV> {
         SV: ProxyHttp + Send + Sync,
         SV::CTX: Send + Sync,
     {
+        #[cfg(windows)]
+        let raw = client_session.id() as std::os::windows::io::RawSocket;
+        #[cfg(unix)]
+        let raw = client_session.id();
+
         if let Err(e) = self
             .inner
             .connected_to_upstream(
                 session,
                 reused,
                 peer,
-                client_session.id(),
+                raw,
                 Some(client_session.digest()),
                 ctx,
             )

--- a/pingora-proxy/src/proxy_h2.rs
+++ b/pingora-proxy/src/proxy_h2.rs
@@ -192,16 +192,14 @@ impl<SV> HttpProxy<SV> {
         SV: ProxyHttp + Send + Sync,
         SV::CTX: Send + Sync,
     {
+        #[cfg(windows)]
+        let raw = client_session.fd() as std::os::windows::io::RawSocket;
+        #[cfg(unix)]
+        let raw = client_session.fd();
+
         if let Err(e) = self
             .inner
-            .connected_to_upstream(
-                session,
-                reused,
-                peer,
-                client_session.fd(),
-                client_session.digest(),
-                ctx,
-            )
+            .connected_to_upstream(session, reused, peer, raw, client_session.digest(), ctx)
             .await
         {
             return (false, Some(e));

--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -425,7 +425,8 @@ pub trait ProxyHttp {
         _session: &mut Session,
         _reused: bool,
         _peer: &HttpPeer,
-        _fd: std::os::unix::io::RawFd,
+        #[cfg(unix)] _fd: std::os::unix::io::RawFd,
+        #[cfg(windows)] _sock: std::os::windows::io::RawSocket,
         _digest: Option<&Digest>,
         _ctx: &mut Self::CTX,
     ) -> Result<()>

--- a/pingora-proxy/src/subrequest.rs
+++ b/pingora-proxy/src/subrequest.rs
@@ -19,6 +19,7 @@ use pingora_cache::lock::WritePermit;
 use pingora_core::protocols::raw_connect::ProxyDigest;
 use pingora_core::protocols::{
     GetProxyDigest, GetSocketDigest, GetTimingDigest, SocketDigest, Ssl, TimingDigest, UniqueID,
+    UniqueIDType,
 };
 use std::io::Cursor;
 use std::sync::Arc;
@@ -68,7 +69,7 @@ impl AsyncWrite for DummyIO {
 }
 
 impl UniqueID for DummyIO {
-    fn id(&self) -> i32 {
+    fn id(&self) -> UniqueIDType {
         0 // placeholder
     }
 }

--- a/pingora-proxy/tests/test_basic.rs
+++ b/pingora-proxy/tests/test_basic.rs
@@ -15,6 +15,7 @@
 mod utils;
 
 use hyper::{body::HttpBody, header::HeaderValue, Body, Client};
+#[cfg(unix)]
 use hyperlocal::{UnixClientExt, Uri};
 use reqwest::{header, StatusCode};
 
@@ -233,6 +234,7 @@ async fn test_h2_to_h1_upload() {
     assert_eq!(body, payload);
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn test_simple_proxy_uds() {
     init();
@@ -262,6 +264,7 @@ async fn test_simple_proxy_uds() {
     assert_eq!(body.as_ref(), b"Hello World!\n");
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn test_simple_proxy_uds_peer() {
     init();

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -192,7 +192,8 @@ impl ProxyHttp for ExampleProxyHttps {
         _http_session: &mut Session,
         reused: bool,
         _peer: &HttpPeer,
-        _fd: std::os::unix::io::RawFd,
+        #[cfg(unix)] _fd: std::os::unix::io::RawFd,
+        #[cfg(windows)] _sock: std::os::windows::io::RawSocket,
         digest: Option<&Digest>,
         ctx: &mut CTX,
     ) -> Result<()> {
@@ -279,6 +280,7 @@ impl ProxyHttp for ExampleProxyHttp {
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
         let req = session.req_header();
+        #[cfg(unix)]
         if req.headers.contains_key("x-uds-peer") {
             return Ok(Box::new(HttpPeer::new_uds(
                 "/tmp/nginx-test.sock",
@@ -310,7 +312,8 @@ impl ProxyHttp for ExampleProxyHttp {
         _http_session: &mut Session,
         reused: bool,
         _peer: &HttpPeer,
-        _fd: std::os::unix::io::RawFd,
+        #[cfg(unix)] _fd: std::os::unix::io::RawFd,
+        #[cfg(windows)] _sock: std::os::windows::io::RawSocket,
         digest: Option<&Digest>,
         ctx: &mut CTX,
     ) -> Result<()> {
@@ -527,6 +530,7 @@ fn test_main() {
     let mut proxy_service_http =
         pingora_proxy::http_proxy_service(&my_server.configuration, ExampleProxyHttp {});
     proxy_service_http.add_tcp("0.0.0.0:6147");
+    #[cfg(unix)]
     proxy_service_http.add_uds("/tmp/pingora_proxy.sock", None);
 
     let mut proxy_service_h2c =

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -29,15 +29,17 @@ pingora-load-balancing = { version = "0.3.0", path = "../pingora-load-balancing"
 pingora-proxy = { version = "0.3.0", path = "../pingora-proxy", optional = true, default-features = false }
 pingora-cache = { version = "0.3.0", path = "../pingora-cache", optional = true, default-features = false }
 
+[target.'cfg(unix)'.dev-dependencies]
+hyperlocal = "0.8"
+jemallocator = "0.5"
+
 [dev-dependencies]
 clap = { version = "3.2.25", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 matches = "0.1"
 env_logger = "0.9"
 reqwest = { version = "0.11", features = ["rustls"], default-features = false }
-hyperlocal = "0.8"
 hyper = "0.14"
-jemallocator = "0.5"
 async-trait = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
Fixes #342 

I know I should wait for a discussion before opening a PR, but I had to implement this regardless due to having to support windows developers in our project. So I thought I could add the PR here as well until you have time to think about it, but ofc no pressure to merge, it is merely opened as a suggestion for how this could be implemented if you are open to the feature, I'm also happy to take feedback if you would like it to be implemented differently somehow.

This adds basic support for windows, it excludes all Unix socket features (e.g `transfer_fd`), it excludes daemonization (the library used in unix-only).

For all uses of `std::os::unix::io::RawFd` on unix systems, windows use `std::os::windows::io::RawSocket`.

For the libc calls `getpeername` and `getsockname` that on unix systems uses the implementation in the `nix`-crate, windows uses a implementation that is based on similar functionality in the std lib (but that unfortunately is private)

I've been testing this with the `x86_64-pc-windows-gnu` target, but I have not been able to cross compile pingora-boringssl to windows. Not sure if it important to test for windows, so didnt spend very much time on it as it is likely just a problem with my local developement environment.

