### PR TITLE
Fix h2 request_summary

### DIFF
--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -20,6 +20,7 @@ use h2::server;
 use h2::server::SendResponse;
 use h2::{RecvStream, SendStream};
 use http::header::HeaderName;
+use http::uri::PathAndQuery;
 use http::{header, HeaderMap, Response};
 use log::{debug, warn};
 use pingora_http::{RequestHeader, ResponseHeader};
@@ -348,7 +349,11 @@ impl HttpSession {
         format!(
             "{} {}, Host: {}:{}",
             self.request_header.method,
-            self.request_header.uri.path(),
+            self.request_header
+                .uri
+                .path_and_query()
+                .map(PathAndQuery::as_str)
+                .unwrap_or_default(),
             self.request_header.uri.host().unwrap_or_default(),
             self.req_header()
                 .uri

--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -348,12 +348,8 @@ impl HttpSession {
         format!(
             "{} {}, Host: {}",
             self.request_header.method,
-            self.request_header.uri,
-            self.request_header
-                .headers
-                .get(header::HOST)
-                .map(|v| String::from_utf8_lossy(v.as_bytes()))
-                .unwrap_or_default()
+            self.request_header.uri.path(),
+            self.request_header.uri.host().unwrap_or_default(),
         )
     }
 

--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -346,10 +346,16 @@ impl HttpSession {
     /// Return a string `$METHOD $PATH $HOST`. Mostly for logging and debug purpose
     pub fn request_summary(&self) -> String {
         format!(
-            "{} {}, Host: {}",
+            "{} {}, Host: {}:{}",
             self.request_header.method,
             self.request_header.uri.path(),
             self.request_header.uri.host().unwrap_or_default(),
+            self.req_header()
+                .uri
+                .port()
+                .as_ref()
+                .map(|port| port.as_str())
+                .unwrap_or_default()
         )
     }
 


### PR DESCRIPTION
Currently, HTTP/2 `request_summary` use HOST header for printing host, which is empty. While the `path` is also different from HTTP/1.x.

Before:

HTTP/1.x:
```log
GET /, Host: example.com:8080
```

HTTP/2:
```log
GET https://example.com:8080/, Host:
```

After this change:
HTTP/2:
```log
GET /, Host: example.com:8080
```