### PR TITLE
Update clap version

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -36,7 +36,7 @@ log = { workspace = true }
 h2 = { workspace = true }
 lru = { workspace = true }
 nix = "~0.24.3"
-clap = { version = "3.2.25", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 once_cell = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -36,7 +36,7 @@ log = { workspace = true }
 h2 = { workspace = true }
 lru = { workspace = true }
 nix = "~0.24.3"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 once_cell = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -137,7 +137,7 @@ pub struct Opt {
 
     /// Not actually used. This flag is there so that the server is not upset seeing this flag
     /// passed from `cargo test` sometimes
-    #[clap(long, hidden = true)]
+    #[clap(long, hide = true)]
     pub nocapture: bool,
 
     /// Test the configuration and exit

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { workspace = true }
 log = { workspace = true }
 h2 = { workspace = true }
 once_cell = { workspace = true }
-clap = { version = "3.2.25", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 regex = "1"
 
 [dev-dependencies]

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { workspace = true }
 log = { workspace = true }
 h2 = { workspace = true }
 once_cell = { workspace = true }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 regex = "1"
 
 [dev-dependencies]

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -30,7 +30,7 @@ pingora-proxy = { version = "0.3.0", path = "../pingora-proxy", optional = true,
 pingora-cache = { version = "0.3.0", path = "../pingora-cache", optional = true, default-features = false }
 
 [dev-dependencies]
-clap = { version = "3.2.25", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 matches = "0.1"
 env_logger = "0.9"

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -30,7 +30,7 @@ pingora-proxy = { version = "0.3.0", path = "../pingora-proxy", optional = true,
 pingora-cache = { version = "0.3.0", path = "../pingora-cache", optional = true, default-features = false }
 
 [dev-dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 matches = "0.1"
 env_logger = "0.9"


### PR DESCRIPTION
Update clap version since the current version depends on `atty` crate which got the following security warning from dependabot:

---

On windows, atty dereferences a potentially unaligned pointer.

In practice however, the pointer won't be unaligned unless a custom global allocator is used.

In particular, the System allocator on windows uses HeapAlloc, which guarantees a large enough alignment.

## atty is Unmaintained

A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.

Last release of atty was almost 3 years ago.