### PR TITLE
Edit github workflow to run audit on latest stable only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Run cargo audit
         run: |
-          [[ ${{ matrix.toolchain }} == nightly ]] || (cargo install cargo-audit && cargo audit)
+          [[ ${{ matrix.toolchain }} != 1.80.0 ]] || (cargo install cargo-audit && cargo audit)


### PR DESCRIPTION
cargo-audit now has an MSRV of 1.74 > ours. We only need to run audit on at least one toolchain, anyhow.