### PR TITLE
Replace non-breaking space with regular space in comments

### DIFF
--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -67,7 +67,7 @@ pub trait Peer: Display + Clone {
     fn tls(&self) -> bool;
     /// The SNI to send, if TLS is used
     fn sni(&self) -> &str;
-    /// To decide whether a [`Peer`] can use the connection established by another [`Peer`].
+    /// To decide whether a [`Peer`] can use the connection established by another [`Peer`].
     ///
     /// The connections to two peers are considered reusable to each other if their reuse hashes are
     /// the same


### PR DESCRIPTION
Replace `C2 A0` with regular space `20`. See https://en.wikipedia.org/wiki/Non-breaking_space.