### PR TITLE
Make opt optional for frontends

### DIFF
--- a/pingora-core/src/server/mod.rs
+++ b/pingora-core/src/server/mod.rs
@@ -176,11 +176,13 @@ impl Server {
     ///
     /// If a configuration file path is provided as part of `opt`, it will be ignored
     /// and a warning will be logged.
-    pub fn new_with_opt_and_conf(opt: Opt, mut conf: ServerConf) -> Server {
-        if let Some(c) = opt.conf.as_ref() {
-            warn!("Ignoring command line argument using '{c}' as configuration, and using provided configuration instead.");
+    pub fn new_with_opt_and_conf(opt: Option<Opt>, mut conf: ServerConf) -> Server {
+        if let Some(opt) = &opt {
+            if let Some(c) = opt.conf.as_ref() {
+                warn!("Ignoring command line argument using '{c}' as configuration, and using provided configuration instead.");
+            }
+            conf.merge_with_opt(&opt);
         }
-        conf.merge_with_opt(&opt);
 
         let (tx, rx) = watch::channel(false);
 
@@ -190,7 +192,7 @@ impl Server {
             shutdown_watch: tx,
             shutdown_recv: rx,
             configuration: Arc::new(conf),
-            options: Some(opt),
+            options: opt,
             sentry: None,
         }
     }


### PR DESCRIPTION
Allow frontends to avoid jumping through hoops to create an Opt object, for example, when configuration is handled by a config file.