### PR TITLE
Add into_inner() for HTTP client and server

### DIFF
--- a/pingora-core/src/protocols/http/v1/client.rs
+++ b/pingora-core/src/protocols/http/v1/client.rs
@@ -664,6 +664,13 @@ impl HttpSession {
     pub fn stream(&self) -> &Stream {
         &self.underlying_stream
     }
+
+    /// Consume `self`, the underlying [Stream] will be returned and can be used
+    /// directly, for example, in the case of HTTP upgrade. It is not flushed
+    /// prior to being returned.
+    pub fn into_inner(self) -> Stream {
+        self.underlying_stream
+    }
 }
 
 #[inline]

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -1010,6 +1010,13 @@ impl HttpSession {
     pub fn stream(&self) -> &Stream {
         &self.underlying_stream
     }
+
+    /// Consume `self`, the underlying stream will be returned and can be used
+    /// directly, for example, in the case of HTTP upgrade. The stream is not
+    /// flushed prior to being returned.
+    pub fn into_inner(self) -> Stream {
+        self.underlying_stream
+    }
 }
 
 // Regex to parse request line that has illegal chars in it


### PR DESCRIPTION
This adds the into_inner() function to the stream type, allowing the HTTP/1.1 client and server to be turned back into a stream.

These functions are useful for implementing HTTP CONNECT or HTTP Upgrade.