### PR TITLE
pingora-core: Update socket dependency

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -55,7 +55,7 @@ sentry = { version = "0.26", features = [
 regex = "1"
 percent-encoding = "2.1"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
-socket2 = { version = "0", features = ["all"] }
+socket2 = { version = ">=0.4, <1.0.0", features = ["all"] }
 flate2 = { version = "1", features = ["zlib-ng"], default-features = false }
 sfv = "0"
 rand = "0.8"


### PR DESCRIPTION
We have the socket version at 0, which matches 0.3 as well. That wont work because it doesn't have feature "all". We need 0.4+.
>=0.4, <1, should match ^0, but exclude 0.3.