### PR TITLE
Remove unused `matches` dependency crate

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -75,7 +75,6 @@ nix = "~0.24.3"
 windows-sys = { version = "0.59.0", features = ["Win32_Networking_WinSock"] }
 
 [dev-dependencies]
-matches = "0.1"
 env_logger = "0.9"
 reqwest = { version = "0.11", features = [
     "rustls-tls",

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -32,7 +32,6 @@ pingora-cache = { version = "0.3.0", path = "../pingora-cache", optional = true,
 [dev-dependencies]
 clap = { version = "3.2.25", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
-matches = "0.1"
 env_logger = "0.9"
 reqwest = { version = "0.11", features = ["rustls"], default-features = false }
 hyper = "0.14"


### PR DESCRIPTION
The minimum version used by rust `edition=2021` is 1.56.0. The `matches` dependency crate was included in the standard library in rust 1.42.0. So the standard library is already there and can remove the unused dependencies.

Reference: https://docs.rs/matches/0.1.10/matches/

> For users who build using only Rust 1.42 and newer, consider using [std::matches](https://doc.rust-lang.org/nightly/core/macro.matches.html), which is included in the [standard library prelude](https://doc.rust-lang.org/stable/reference/names/preludes.html) and thus is automatically in scope.