### PR TITLE
fixed unused manifest key

### DIFF
--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -63,6 +63,3 @@ sentry = ["pingora-core/sentry"]
 # or locally cargo doc --config "build.rustdocflags='--cfg doc_async_trait'"
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "doc_async_trait"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_async_trait)'] }


### PR DESCRIPTION
```shell
# cargo test
warning: /root/TEMP/pingora/pingora-proxy/Cargo.toml: unused manifest key: lints.rust.unexpected_cfgs.check-cfg

# cargo build
warning: /root/TEMP/pingora/pingora-proxy/Cargo.toml: unused manifest key: lints.rust.unexpected_cfgs.check-cfg
```

rust version:

```shell
# rustc --version
rustc 1.78.0 (9b00956e5 2024-04-29)
```