### PR TITLE
Update quickstart to support Opt::parse_args

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -19,7 +19,7 @@ cargo new load_balancer
 In your project's `cargo.toml` file add the following to your dependencies
 ```
 async-trait="0.1"
-pingora = { version = "0.1", features = [ "lb" ] }
+pingora = { version = "0.3", features = [ "lb" ] }
 ```
 
 ### Create a pingora server


### PR DESCRIPTION
The current quickstart document suggests to use pingora v0.1, but it also suggests using the Opt::parse_args interface, which was introduced in release v0.3.0. Update the quickstart document to suggest using v0.3 when setting up the cargo.toml file.

Addresses #432