### PR TITLE
Fix audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate Cargo.lock
+        # https://github.com/rustsec/audit-check/issues/27
+        run: cargo generate-lockfile
+
       - name: Audit Check
         # https://github.com/rustsec/audit-check/issues/2
         uses: rustsec/audit-check@master


### PR DESCRIPTION
I noticed that the audit workflow failed every night on my fork. It is because the .lock file is not checked in, see https://github.com/rustsec/audit-check/issues/27

Tested here: https://github.com/fredr/pingora/actions/runs/11590217912