### PR TITLE
Fixed RUSTLS on Windows Compilation

### DIFF
--- a/pingora-core/src/protocols/tls/rustls/stream.rs
+++ b/pingora-core/src/protocols/tls/rustls/stream.rs
@@ -216,7 +216,13 @@ impl<T> UniqueID for TlsStream<T>
 where
     T: UniqueID,
 {
+    #[cfg(not(target_os = "windows"))]
     fn id(&self) -> i32 {
+        self.tls.stream.as_ref().unwrap().get_ref().0.id()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn id(&self) -> usize {
         self.tls.stream.as_ref().unwrap().get_ref().0.id()
     }
 }


### PR DESCRIPTION
Migrated my project to windows and had issues compiling the underlying pingora lib's modifed the compilation of the impl UniqueID for TlsStream and it allowewd me to compile. I am still familiarizing myself with the code base so I am unsure if this is the best way to do this but it worked for me. 