### PR TITLE
fix: update `impl<T> UniqueID` to use correct return type

### DIFF
--- a/pingora-core/src/protocols/tls/rustls/stream.rs
+++ b/pingora-core/src/protocols/tls/rustls/stream.rs
@@ -216,7 +216,7 @@ impl<T> UniqueID for TlsStream<T>
 where
     T: UniqueID,
 {
-    fn id(&self) -> i32 {
+    fn id(&self) -> UniqueIDType {
         self.tls.stream.as_ref().unwrap().get_ref().0.id()
     }
 }


### PR DESCRIPTION
The trait `UniqueID` requires `UniqueIDType` in the `id` function signature, so explicitly using the type `i32` here is wrong as `UniqueIDType` is conditionally compiled to different types in Linux and Windows.