### PR TITLE
Fix and update quick start dependency section

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -16,10 +16,10 @@ cargo new load_balancer
 
 ### Include the Pingora Crate and Basic Dependencies
 
-In your project's `cargo.toml` file add the following to your dependencies
+In your project's `Cargo.toml` file add the following to your dependencies
 ```
-async-trait="0.1"
-pingora = { version = "0.3", features = [ "lb" ] }
+async-trait = "0.1"
+pingora = { version = "0.4", features = [ "lb", "openssl" ] }
 ```
 
 ### Create a pingora server


### PR DESCRIPTION
This PR does three things:
1. Fixes a typo for `Cargo.toml` and correctly formats the snippet
2. Upgrades to pingora 0.4 (which I have tested with the quick start code and it still works as far as I can tell)
3. Added the `openssl` feature, this is so that after following the quickstart guide and opening http://localhost:6188 it will work with TLS and display the one.one.one.one page