### PR TITLE
Run cargo machete in github CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   pingora:
     strategy:
       matrix:
+        # nightly, MSRV, and latest stable
         toolchain: [nightly, 1.72, 1.82.0]
     runs-on: ubuntu-latest
     # Only run on "pull_request" event for external PRs. This is to avoid
@@ -51,3 +52,7 @@ jobs:
       - name: Run cargo audit
         run: |
           [[ ${{ matrix.toolchain }} != 1.82.0 ]] || (cargo install cargo-audit && cargo audit)
+
+      - name: Run cargo machete
+        run: |
+          [[ ${{ matrix.toolchain }} != 1.72.0 ]] || (cargo install cargo-machete && cargo machete)


### PR DESCRIPTION
Relates to https://github.com/cloudflare/pingora/pull/454 and ae9c80bb47804f2913e49f82eaaa28294f81a458. The `.github` CI portion of this was not actioned.