### PR TITLE
allow proxy to set stream level downstream read timeout

### DIFF
--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -188,8 +188,19 @@ impl Session {
         }
     }
 
+    /// Sets the downstream read timeout. This will trigger if we're unable
+    /// to read from the stream after `timeout`.
+    /// 
+    /// This is a noop for h2.
+    pub fn set_read_timeout(&mut self, timeout: Duration) {
+        match self {
+            Self::H1(s) => s.set_write_timeout(timeout),
+            Self::H2(_) => {}
+        }
+    }
+
     /// Sets the downstream write timeout. This will trigger if we're unable
-    /// to write to the stream after `duration`. If a `min_send_rate` is
+    /// to write to the stream after `timeout`. If a `min_send_rate` is
     /// configured then the `min_send_rate` calculated timeout has higher priority.
     ///
     /// This is a noop for h2.

--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -194,7 +194,7 @@ impl Session {
     /// This is a noop for h2.
     pub fn set_read_timeout(&mut self, timeout: Duration) {
         match self {
-            Self::H1(s) => s.set_write_timeout(timeout),
+            Self::H1(s) => s.set_read_timeout(timeout),
             Self::H2(_) => {}
         }
     }
@@ -218,7 +218,7 @@ impl Session {
     /// rate must be greater than zero.
     ///
     /// Calculated write timeout is guaranteed to be at least 1s if `min_send_rate`
-    /// is greater than zero, a send rate of zero is a noop.
+    /// is greater than zero, a send rate of zero is a noop.x
     ///
     /// This is a noop for h2.
     pub fn set_min_send_rate(&mut self, rate: usize) {

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -823,8 +823,14 @@ impl HttpSession {
         }
     }
 
+    /// Sets the downstream read timeout. This will trigger if we're unable
+    /// to read from the stream after `timeout`.
+    pub fn set_read_timeout(&mut self, timeout: Duration) {
+        self.read_timeout = Some(timeout);
+    }
+
     /// Sets the downstream write timeout. This will trigger if we're unable
-    /// to write to the stream after `duration`. If a `min_send_rate` is
+    /// to write to the stream after `timeout`. If a `min_send_rate` is
     /// configured then the `min_send_rate` calculated timeout has higher priority.
     pub fn set_write_timeout(&mut self, timeout: Duration) {
         self.write_timeout = Some(timeout);


### PR DESCRIPTION
these timeouts were already implemented and had unit tests, but were missing the API on the Session to allow configurability from ProxyHttp callbacks. 