### PR TITLE
cleanup: examples should use reexported clap dep

### DIFF
--- a/pingora-proxy/examples/backoff_retry.rs
+++ b/pingora-proxy/examples/backoff_retry.rs
@@ -15,7 +15,6 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use clap::Parser;
 
 use log::info;
 use pingora_core::server::Server;
@@ -79,7 +78,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/ctx.rs
+++ b/pingora-proxy/examples/ctx.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use clap::Parser;
 use log::info;
 use std::sync::Mutex;
 
@@ -82,7 +81,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/gateway.rs
+++ b/pingora-proxy/examples/gateway.rs
@@ -14,7 +14,6 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use clap::Parser;
 use log::info;
 use prometheus::register_int_counter;
 
@@ -117,7 +116,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/grpc_web_module.rs
+++ b/pingora-proxy/examples/grpc_web_module.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use clap::Parser;
 
 use pingora_core::server::Server;
 use pingora_core::upstreams::peer::HttpPeer;
@@ -77,7 +76,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/load_balancer.rs
+++ b/pingora-proxy/examples/load_balancer.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use clap::Parser;
 use log::info;
 use pingora_core::services::background::background_service;
 use std::{sync::Arc, time::Duration};
@@ -62,7 +61,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/modify_response.rs
+++ b/pingora-proxy/examples/modify_response.rs
@@ -14,7 +14,6 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::net::ToSocketAddrs;
 
@@ -117,7 +116,7 @@ impl ProxyHttp for Json2Yaml {
 fn main() {
     env_logger::init();
 
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 

--- a/pingora-proxy/examples/use_module.rs
+++ b/pingora-proxy/examples/use_module.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use clap::Parser;
 
 use pingora_core::modules::http::HttpModules;
 use pingora_core::server::configuration::Opt;
@@ -115,7 +114,7 @@ fn main() {
     env_logger::init();
 
     // read command line arguments
-    let opt = Opt::parse();
+    let opt = Opt::parse_args();
     let mut my_server = Server::new(Some(opt)).unwrap();
     my_server.bootstrap();
 


### PR DESCRIPTION
I'm refactoring a bit of code