### PR TITLE
Fixes GitHub Actions to succeed again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Pin crates to versions for MSRV
         run: |
-          [[ ${{ matrix.toolchain }} != 1.72.0 ]] || cargo update -p boring --precise 4.13.0
+          [[ ${{ matrix.toolchain }} != 1.72.0 ]] || (cargo update -p boring --precise 4.13.0 && cargo update -p litemap --precise 0.7.4 && cargo update -p zerofrom --precise 0.1.5)
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ name: build
 jobs:
   pingora:
     strategy:
+      fail-fast: false
       matrix:
         # nightly, MSRV, and latest stable
         toolchain: [nightly, 1.72.0, 1.82.0]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: Run cargo machete
         run: |
-          [[ ${{ matrix.toolchain }} != 1.82.0 ]] || (cargo install cargo-machete && cargo machete)
+          [[ ${{ matrix.toolchain }} != 1.82.0 ]] || (cargo install cargo-machete --version 0.7.0 && cargo machete)


### PR DESCRIPTION
Addresses current build/action failures:

### Rust toolchain 1.82.0
* Pins `cargo-machete` crate to `0.7.0`, because latest version `0.8.0` requires `edition2024`: https://crates.io/crates/cargo-machete/versions

### Rust toolchain 1.72.0
* Pins `litemap` crate to `0.7.4`, because latest version `0.7.5` requires minimum Rust version 1.81 or newer
* Pins `zerofrom` crate to `0.1.5`, because latest version `0.1.6` requires minimum Rust version 1.81 or newer

### Fail fast
This also disables `fail-fast`, so that all toolchains continue to run until their own failure, making it easier to debug & fix toolchain-specific problems.