### PR TITLE
Fix broken `rustdoc` links

### DIFF
--- a/pingora-memory-cache/src/lib.rs
+++ b/pingora-memory-cache/src/lib.rs
@@ -137,7 +137,7 @@ impl<K: Hash, T: Clone + Send + Sync + 'static> MemoryCache<K, T> {
         }
     }
 
-    /// Similar to [get], fetch the key and return its value in addition to a
+    /// Similar to [Self::get], fetch the key and return its value in addition to a
     /// [CacheStatus] but also return the value even if it is expired. When the
     /// value is expired, the [Duration] of how long it has been stale will
     /// also be returned.

--- a/pingora-memory-cache/src/read_through.rs
+++ b/pingora-memory-cache/src/read_through.rs
@@ -284,7 +284,7 @@ where
         }
     }
 
-    /// Similar to [get], query the cache for a given value, but also returns the value even if the
+    /// Similar to [Self::get], query the cache for a given value, but also returns the value even if the
     /// value is expired up to `stale_ttl`. If it is a cache miss or the value is stale more than
     /// the `stale_ttl`, a lookup will be performed to populate the cache.
     pub async fn get_stale(
@@ -313,11 +313,13 @@ where
     S: Clone + Send + Sync,
     CB: Lookup<K, T, S> + Sync + Send,
 {
-    /// Similar to [get_stale], but when it returns the stale value, it also initiates a lookup
+    /// Similar to [Self::get_stale], but when it returns the stale value, it also initiates a lookup
     /// in the background in order to refresh the value.
     ///
     /// Note that this function requires the [RTCache] to be static, which can be done by wrapping
     /// it with something like [once_cell::sync::Lazy].
+    ///
+    /// [once_cell::sync::Lazy]: https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html
     pub async fn get_stale_while_update(
         &'static self,
         key: &K,

--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -225,6 +225,8 @@ pub trait ProxyHttp {
     /// It also allow users to modify the response header accordingly.
     ///
     /// The default implementation can handle a single-range as per [RFC7232].
+    ///
+    /// [RFC7232]: https://www.rfc-editor.org/rfc/rfc7232
     fn range_header_filter(
         &self,
         req: &RequestHeader,


### PR DESCRIPTION
There are some occurrences of broken `rustdoc` links. They are reported as a warning when running `cargo doc`, there is already a CI job run that executes doc generation, yet the pipeline still finishes successfully. Maybe it would be better to treat warnings as errors?