### PR TITLE
Add sni to the SSL session digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest as builder
+FROM debian:latest AS builder
 
 ARG BUILDARCH
 RUN apt-get -qq update \
@@ -6,6 +6,7 @@ RUN apt-get -qq update \
        gcc g++ libfindbin-libs-perl \
        make cmake libclang-dev git \
        wget curl gnupg ca-certificates lsb-release \
+       jq \
     && wget --no-check-certificate -O - https://openresty.org/package/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/openresty.gpg \
     && if [ "${BUILDARCH}" = "arm64" ]; then URL="http://openresty.org/package/arm64/debian"; else URL="http://openresty.org/package/debian"; fi \
     && echo "deb [arch=$BUILDARCH signed-by=/usr/share/keyrings/openresty.gpg] ${URL} $(lsb_release -sc) openresty" | tee /etc/apt/sources.list.d/openresty.list > /dev/null \
@@ -17,4 +18,12 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /var/opt/pingora
 COPY . .
+
+# build one at a time because of conflicting cfg
 RUN cargo build
+RUN cargo build --features "openssl"
+RUN cargo build --features "boringssl"
+RUN cargo build --features "rustls"
+RUN cargo build --features "lb"
+RUN cargo build --features "proxy "
+RUN cargo build --features "cache"

--- a/pingora-core/src/protocols/tls/boringssl_openssl/stream.rs
+++ b/pingora-core/src/protocols/tls/boringssl_openssl/stream.rs
@@ -14,6 +14,7 @@
 
 use crate::protocols::digest::TimingDigest;
 use crate::protocols::tls::{SslDigest, ALPN};
+use crate::protocols::tls::boringssl_openssl::stream::ssl::NameType;
 use crate::protocols::{Peek, Ssl, UniqueID, UniqueIDType};
 use crate::tls::{self, ssl, tokio_ssl::SslStream as InnerSsl};
 use crate::utils::tls::{get_organization, get_serial};
@@ -202,6 +203,8 @@ impl SslDigest {
             }
             None => (Vec::new(), None, None),
         };
+        let sni = ssl.servername(NameType::HOST_NAME);
+        let sni_string: Option<String> = sni.map(ToOwned::to_owned);
 
         SslDigest {
             cipher,
@@ -209,6 +212,7 @@ impl SslDigest {
             organization: org,
             serial_number: sn,
             cert_digest,
+            sni: sni_string,
         }
     }
 }

--- a/pingora-core/src/protocols/tls/digest.rs
+++ b/pingora-core/src/protocols/tls/digest.rs
@@ -27,4 +27,7 @@ pub struct SslDigest {
     pub serial_number: Option<String>,
     /// The digest of the peer's certificate
     pub cert_digest: Vec<u8>,
+    /// the SNI used in the negotiation
+    pub sni: Option<String>,
+
 }

--- a/pingora-core/src/protocols/tls/rustls/stream.rs
+++ b/pingora-core/src/protocols/tls/rustls/stream.rs
@@ -384,12 +384,15 @@ impl SslDigest {
             .map(|(organization, serial)| (organization, Some(serial)))
             .unwrap_or_default();
 
+        let sni = None;
+
         SslDigest {
             cipher,
             version,
             organization,
             serial_number,
             cert_digest,
+            sni,
         }
     }
 }


### PR DESCRIPTION
See issue #547 

This PR adds the SNI to the session digest for SSL.

Rustls is stubbed because I couldn't figure out how to get it.  Be happy to include that if someone can give me a hint.

I note to get the modified code to compile for Docker I had to modify the Dockerfile, as it looks like it hasn't kept up with the changes in optional modules.  If you need an issue for that let me know.  I doubt the patch is perfectly complete, the documentation on how to build all the options doesn't seem to be anywhere I can find it (and building with all options simultaneously breaks the build)