### PR TITLE
Temporary `sfv` solution

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -57,7 +57,7 @@ percent-encoding = "2.1"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 socket2 = { version = ">=0.4, <1.0.0", features = ["all"] }
 flate2 = { version = "1", features = ["zlib-ng"], default-features = false }
-sfv = "0"
+sfv = "0.10.4"
 rand = "0.8"
 ahash = { workspace = true }
 unicase = "2"


### PR DESCRIPTION
I saw @BSteffaniak as long term solution to bump the things so it could match the sfv version and their fixed which explained in this PR [#569](https://github.com/cloudflare/pingora/pull/569), but i see there is still rust 1.72 in the pingora build-test. So I propose to downgrade temporarily until maintainers came up with the decision

- dropping rust 1.72 test-case
- merging the #569 PR

which on this PR i change from `0` to exact `0.10.4` last working version
