### PR TITLE
chore: update flate2 version & use zlib-rs

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -56,7 +56,7 @@ regex = "1"
 percent-encoding = "2.1"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 socket2 = { version = ">=0.4, <1.0.0", features = ["all"] }
-flate2 = { version = "1", features = ["zlib-ng"], default-features = false }
+flate2 = { version = "1.1", features = ["zlib-rs"], default-features = false }
 sfv = "0"
 rand = "0.8"
 ahash = { workspace = true }


### PR DESCRIPTION
As described in this blog post https://trifectatech.org/blog/zlib-rs-is-faster-than-c/ zlib-rs is a faster and pure Rust zlib alternative and those performance upgrades are included in flate2 `1.1`.

What are your thoughts on adopting it?