### PR TITLE
`HttpPeer::new`. Return `Result<Self>` instead of `panic`

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -80,7 +80,7 @@ impl ProxyHttp for LB {
         println!("upstream peer is: {upstream:?}");
 
         // Set SNI to one.one.one.one
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }
@@ -136,8 +136,8 @@ fn main() {
 
 ### Run it
 
-Now that we have added the load balancer to the service, we can run our new 
-project with 
+Now that we have added the load balancer to the service, we can run our new
+project with
 
 ```cargo run```
 
@@ -158,24 +158,24 @@ upstream peer is: Backend { addr: Inet(1.0.0.1:443), weight: 1 }
 ...
 ```
 
-Well done! At this point you have a functional load balancer. It is a _very_ 
+Well done! At this point you have a functional load balancer. It is a _very_
 basic load balancer though, so the next section will walk you through how to
 make it more robust with some built-in pingora tooling.
 
 ## Add functionality
 
-Pingora provides several helpful features that can be enabled and configured 
-with just a few lines of code. These range from simple peer health checks to 
+Pingora provides several helpful features that can be enabled and configured
+with just a few lines of code. These range from simple peer health checks to
 the ability to seamlessly update running binary with zero service interruptions.
 
 ### Peer health checks
 
-To make our load balancer more reliable, we would like to add some health checks 
-to our upstream peers. That way if there is a peer that has gone down, we can 
+To make our load balancer more reliable, we would like to add some health checks
+to our upstream peers. That way if there is a peer that has gone down, we can
 quickly stop routing our traffic to that peer.
 
 First let's see how our simple load balancer behaves when one of the peers is
-down. To do this, we'll update the list of peers to include a peer that is 
+down. To do this, we'll update the list of peers to include a peer that is
 guaranteed to be broken.
 
 ```rust
@@ -187,16 +187,16 @@ fn main() {
 }
 ```
 
-Now if we run our load balancer again with `cargo run`, and test it with 
+Now if we run our load balancer again with `cargo run`, and test it with
 
 ```
 curl 127.0.0.1:6188 -svo /dev/null
 ```
 
-We can see that one in every 3 request fails with `502: Bad Gateway`. This is 
-because our peer selection is strictly following the `RoundRobin` selection 
+We can see that one in every 3 request fails with `502: Bad Gateway`. This is
+because our peer selection is strictly following the `RoundRobin` selection
 pattern we gave it with no consideration to whether that peer is healthy. We can
-fix this by adding a basic health check service. 
+fix this by adding a basic health check service.
 
 ```rust
 fn main() {
@@ -225,15 +225,15 @@ fn main() {
 }
 ```
 
-Now if we again run and test our load balancer, we see that all requests 
-succeed and the broken peer is never used. Based on the configuration we used, 
+Now if we again run and test our load balancer, we see that all requests
+succeed and the broken peer is never used. Based on the configuration we used,
 if that peer were to become healthy again, it would be re-included in the round
 robin again in within 1 second.
 
 ### Command line options
 
 The pingora `Server` type provides a lot of built-in functionality that we can
-take advantage of with single-line change. 
+take advantage of with single-line change.
 
 ```rust
 fn main() {
@@ -242,15 +242,15 @@ fn main() {
 }
 ```
 
-With this change, the command-line arguments passed to our load balancer will be 
+With this change, the command-line arguments passed to our load balancer will be
 consumed by Pingora. We can test this by running:
 
 ```
 cargo run -- -h
 ```
 
-We should see a help menu with the list of arguments now available to us. We 
-will take advantage of those in the next sections to do more with our load 
+We should see a help menu with the list of arguments now available to us. We
+will take advantage of those in the next sections to do more with our load
 balancer for free
 
 ### Running in the background
@@ -268,9 +268,9 @@ pkill -SIGTERM load_balancer
  (`SIGTERM` is the default signal for `pkill`.)
 
 ### Configurations
-Pingora configuration files help define how to run the service. Here is an 
-example config file that defines how many threads the service can have, the 
-location of the pid file, the error log file, and the upgrade coordination 
+Pingora configuration files help define how to run the service. Here is an
+example config file that defines how many threads the service can have, the
+location of the pid file, the error log file, and the upgrade coordination
 socket (which we will explain later). Copy the contents below and put them into
 a file called `conf.yaml` in your `load_balancer` project directory.
 

--- a/docs/user_guide/ctx.md
+++ b/docs/user_guide/ctx.md
@@ -43,7 +43,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443)
         };
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }
@@ -104,7 +104,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443)
         };
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }

--- a/docs/user_guide/failover.md
+++ b/docs/user_guide/failover.md
@@ -59,7 +59,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443)
         };
 
-        let mut peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let mut peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         peer.options.connection_timeout = Some(Duration::from_millis(100));
         Ok(peer)
     }

--- a/docs/user_guide/modify_filter.md
+++ b/docs/user_guide/modify_filter.md
@@ -28,7 +28,7 @@ impl ProxyHttp for MyGateway {
 
         info!("connecting to {addr:?}");
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }

--- a/docs/user_guide/rate_limiter.md
+++ b/docs/user_guide/rate_limiter.md
@@ -85,7 +85,7 @@ impl ProxyHttp for LB {
     ) -> Result<Box<HttpPeer>> {
         let upstream = self.0.select(b"", 256).unwrap();
         // Set SNI
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 
@@ -135,11 +135,11 @@ impl ProxyHttp for LB {
 ```
 
 ## Testing
-To use the example above, 
+To use the example above,
 
-1. Run your program with `cargo run`. 
+1. Run your program with `cargo run`.
 2. Verify the program is working with a few executions of ` curl localhost:6188 -H "appid:1" -v`
-   - The first request should work and any later requests that arrive within 1s of a previous request should fail with: 
+   - The first request should work and any later requests that arrive within 1s of a previous request should fail with:
      ```
      *   Trying 127.0.0.1:6188...
      * Connected to localhost (127.0.0.1) port 6188 (#0)
@@ -148,19 +148,19 @@ To use the example above,
      > User-Agent: curl/7.88.1
      > Accept: */*
      > appid:1
-     > 
+     >
      < HTTP/1.1 429 Too Many Requests
      < X-Rate-Limit-Limit: 1
      < X-Rate-Limit-Remaining: 0
      < X-Rate-Limit-Reset: 1
      < Date: Sun, 14 Jul 2024 20:29:02 GMT
      < Connection: close
-     < 
+     <
      * Closing connection 0
      ```
 
 ## Complete Example
-You can run the pre-made example code in the [`pingora-proxy` examples folder](https://github.com/cloudflare/pingora/tree/main/pingora-proxy/examples/rate_limiter.rs) with 
+You can run the pre-made example code in the [`pingora-proxy` examples folder](https://github.com/cloudflare/pingora/tree/main/pingora-proxy/examples/rate_limiter.rs) with
 
 ```
 cargo run --example rate_limiter

--- a/pingora-core/src/connectors/http/mod.rs
+++ b/pingora-core/src/connectors/http/mod.rs
@@ -116,7 +116,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect_h2() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(2, 2);
         let (h2, reused) = connector.get_http_session(&peer).await.unwrap();
         assert!(!reused);
@@ -139,7 +139,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect_h1() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(1, 1);
         let (mut h1, reused) = connector.get_http_session(&peer).await.unwrap();
         assert!(!reused);
@@ -166,7 +166,7 @@ mod tests {
         // h1 session instead.
 
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         // As it is hard to find a server that support only h1, we use the following hack to trick
         // the connector to think the server supports only h1. We force ALPN to use h1 and then
         // return the connection to the Connector. And then we use a Peer that allows h2
@@ -181,7 +181,7 @@ mod tests {
         }
         connector.release_http_session(h1, &peer, None).await;
 
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(2, 1);
 
         let (mut h1, reused) = connector.get_http_session(&peer).await.unwrap();
@@ -196,7 +196,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect_prefer_h1() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(2, 1);
         connector.prefer_h1(&peer);
 

--- a/pingora-core/src/connectors/http/v1.rs
+++ b/pingora-core/src/connectors/http/v1.rs
@@ -84,7 +84,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect() {
         let connector = Connector::new(None);
-        let peer = HttpPeer::new(("1.1.1.1", 80), false, "".into());
+        let peer = HttpPeer::new(("1.1.1.1", 80), false, "".into()).unwrap();
         // make a new connection to 1.1.1.1
         let (http, reused) = connector.get_http_session(&peer).await.unwrap();
         let server_addr = http.server_addr().unwrap();
@@ -106,7 +106,7 @@ mod tests {
     #[cfg(feature = "any_tls")]
     async fn test_connect_tls() {
         let connector = Connector::new(None);
-        let peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         // make a new connection to https://1.1.1.1
         let (http, reused) = connector.get_http_session(&peer).await.unwrap();
         let server_addr = http.server_addr().unwrap();

--- a/pingora-core/src/connectors/http/v2.rs
+++ b/pingora-core/src/connectors/http/v2.rs
@@ -466,7 +466,7 @@ mod tests {
     #[cfg(feature = "any_tls")]
     async fn test_connect_h2() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(2, 2);
         let h2 = connector.new_http_session(&peer).await.unwrap();
         match h2 {
@@ -479,7 +479,7 @@ mod tests {
     #[cfg(feature = "any_tls")]
     async fn test_connect_h1() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         // a hack to force h1, new_http_session() in the future might validate this setting
         peer.options.set_http_version(1, 1);
         let h2 = connector.new_http_session(&peer).await.unwrap();
@@ -492,7 +492,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect_h1_plaintext() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 80), false, "".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 80), false, "".into()).unwrap();
         peer.options.set_http_version(2, 1);
         let h2 = connector.new_http_session(&peer).await.unwrap();
         match h2 {
@@ -505,7 +505,7 @@ mod tests {
     #[cfg(feature = "any_tls")]
     async fn test_h2_single_stream() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(2, 2);
         peer.options.max_h2_streams = 1;
         let h2 = connector.new_http_session(&peer).await.unwrap();
@@ -537,7 +537,7 @@ mod tests {
     #[cfg(feature = "any_tls")]
     async fn test_h2_multiple_stream() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 443), true, "one.one.one.one".into()).unwrap();
         peer.options.set_http_version(2, 2);
         peer.options.max_h2_streams = 3;
         let h2 = connector.new_http_session(&peer).await.unwrap();

--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -363,7 +363,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_conn_error_addr_not_avail() {
-        let peer = HttpPeer::new("127.0.0.1:121".to_string(), false, "".to_string());
+        let peer = HttpPeer::new("127.0.0.1:121".to_string(), false, "".to_string()).unwrap();
         let addr = "192.0.2.2:0".parse().ok();
         let bind_to = BindTo {
             addr,
@@ -375,7 +375,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_conn_error_other() {
-        let peer = HttpPeer::new("240.0.0.1:80".to_string(), false, "".to_string()); // non localhost
+        let peer = HttpPeer::new("240.0.0.1:80".to_string(), false, "".to_string()).unwrap(); // non localhost
         let addr = "127.0.0.1:0".parse().ok();
         // create an error: cannot send from src addr: localhost to dst addr: a public IP
         let bind_to = BindTo {
@@ -443,7 +443,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_connect_proxy_fail() {
-        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
+        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string()).unwrap();
         let mut path = PathBuf::new();
         path.push("/tmp/123");
         peer.proxy = Some(Proxy {
@@ -481,7 +481,7 @@ mod tests {
         });
         // wait for the server to start
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
+        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string()).unwrap();
         let mut path = PathBuf::new();
         path.push(MOCK_UDS_PATH);
         peer.proxy = Some(Proxy {
@@ -518,7 +518,7 @@ mod tests {
         });
         // wait for the server to start
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
+        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string()).unwrap();
         let mut path = PathBuf::new();
         path.push(MOCK_BAD_UDS_PATH);
         peer.proxy = Some(Proxy {
@@ -584,7 +584,7 @@ mod tests {
         let (low, _) = get_ip_local_port_range();
         let high = low + 1;
 
-        let peer = HttpPeer::new(format!("127.0.0.1:{port}"), false, "".to_string());
+        let peer = HttpPeer::new(format!("127.0.0.1:{port}"), false, "".to_string()).unwrap();
         let mut bind_to = BindTo {
             addr: "127.0.0.1:0".parse().ok(),
             ..Default::default()

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -467,10 +467,10 @@ impl HttpPeer {
     }
 
     /// Create a new [`HttpPeer`] with the given socket address and TLS settings.
-    pub fn new<A: ToInetSocketAddrs>(address: A, tls: bool, sni: String) -> Self {
-        let mut addrs_iter = address.to_socket_addrs().unwrap(); //TODO: handle error
+    pub fn new<A: ToInetSocketAddrs>(address: A, tls: bool, sni: String) -> Result<Self> {
+        let mut addrs_iter = address.to_socket_addrs().or_err(SocketError, "invalid address")?;
         let addr = addrs_iter.next().unwrap();
-        Self::new_from_sockaddr(SocketAddr::Inet(addr), tls, sni)
+        Ok(Self::new_from_sockaddr(SocketAddr::Inet(addr), tls, sni))
     }
 
     /// Create a new [`HttpPeer`] with the given path to Unix domain socket and TLS settings.

--- a/pingora-load-balancing/src/health_check.rs
+++ b/pingora-load-balancing/src/health_check.rs
@@ -187,7 +187,7 @@ impl HttpHealthCheck {
         let mut req = RequestHeader::build("GET", b"/", None).unwrap();
         req.append_header("Host", host).unwrap();
         let sni = if tls { host.into() } else { String::new() };
-        let mut peer_template = HttpPeer::new("0.0.0.0:1", tls, sni);
+        let mut peer_template = HttpPeer::new("0.0.0.0:1", tls, sni).unwrap();
         peer_template.options.connection_timeout = Some(Duration::from_secs(1));
         peer_template.options.read_timeout = Some(Duration::from_secs(1));
         HttpHealthCheck {

--- a/pingora-proxy/examples/backoff_retry.rs
+++ b/pingora-proxy/examples/backoff_retry.rs
@@ -67,7 +67,7 @@ impl ProxyHttp for BackoffRetryProxy {
             info!("sleeping for ms: {sleep_ms:?}");
             tokio::time::sleep(sleep_ms).await;
         }
-        let mut peer = HttpPeer::new(("10.0.0.1", 80), false, "".into());
+        let mut peer = HttpPeer::new(("10.0.0.1", 80), false, "".into())?;
         peer.options.connection_timeout = Some(Duration::from_millis(100));
         Ok(Box::new(peer))
     }

--- a/pingora-proxy/examples/ctx.rs
+++ b/pingora-proxy/examples/ctx.rs
@@ -70,7 +70,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443)
         };
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }

--- a/pingora-proxy/examples/gateway.rs
+++ b/pingora-proxy/examples/gateway.rs
@@ -65,7 +65,7 @@ impl ProxyHttp for MyGateway {
 
         info!("connecting to {addr:?}");
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/grpc_web_module.rs
+++ b/pingora-proxy/examples/grpc_web_module.rs
@@ -66,7 +66,7 @@ impl ProxyHttp for GrpcWebBridgeProxy {
             ("1.1.1.1", 443),
             true,
             "one.one.one.one".to_string(),
-        ));
+        )?);
         Ok(grpc_peer)
     }
 }

--- a/pingora-proxy/examples/load_balancer.rs
+++ b/pingora-proxy/examples/load_balancer.rs
@@ -40,7 +40,7 @@ impl ProxyHttp for LB {
 
         info!("upstream peer is: {:?}", upstream);
 
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/modify_response.rs
+++ b/pingora-proxy/examples/modify_response.rs
@@ -52,7 +52,7 @@ impl ProxyHttp for Json2Yaml {
         _session: &mut Session,
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
-        let peer = Box::new(HttpPeer::new(self.addr, false, HOST.to_owned()));
+        let peer = Box::new(HttpPeer::new(self.addr, false, HOST.to_owned())?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/multi_lb.rs
+++ b/pingora-proxy/examples/multi_lb.rs
@@ -48,7 +48,7 @@ impl ProxyHttp for Router {
         println!("upstream peer is: {upstream:?}");
 
         // Set SNI to one.one.one.one
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }

--- a/pingora-proxy/examples/rate_limiter.rs
+++ b/pingora-proxy/examples/rate_limiter.rs
@@ -68,7 +68,7 @@ impl ProxyHttp for LB {
     ) -> Result<Box<HttpPeer>> {
         let upstream = self.0.select(b"", 256).unwrap();
         // Set SNI
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/use_module.rs
+++ b/pingora-proxy/examples/use_module.rs
@@ -102,7 +102,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443),
             true,
             "one.one.one.one".to_string(),
-        ));
+        )?);
         Ok(peer)
     }
 }

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -136,7 +136,7 @@ impl ProxyHttp for ExampleProxyHttps {
             format!("127.0.0.1:{port}"),
             true,
             sni.to_string(),
-        ));
+        )?);
         peer.options.alternative_cn = Some(alt.to_string());
 
         let verify = session.get_header_bytes("verify") == b"1";
@@ -300,7 +300,7 @@ impl ProxyHttp for ExampleProxyHttp {
             format!("127.0.0.1:{port}"),
             false,
             "".to_string(),
-        ));
+        )?);
 
         if session.get_header_bytes("x-h2") == b"true" {
             // default is 1, 1
@@ -365,7 +365,7 @@ impl ProxyHttp for ExampleProxyCache {
             format!("127.0.0.1:{}", port),
             false,
             "".to_string(),
-        ));
+        )?);
 
         if session.get_header_bytes("x-h2") == b"true" {
             // default is 1, 1

--- a/pingora/examples/client.rs
+++ b/pingora/examples/client.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     // create the HTTP session
     let peer_addr = "1.1.1.1:443";
-    let mut peer = HttpPeer::new(peer_addr, true, "one.one.one.one".into());
+    let mut peer = HttpPeer::new(peer_addr, true, "one.one.one.one".into())?;
     peer.options.set_http_version(2, 1);
     let (mut http, _reused) = connector.get_http_session(&peer).await?;
 


### PR DESCRIPTION
Relates: https://github.com/cloudflare/pingora/issues/570