### PR TITLE
Update and pin sfv to v11 #568

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # nightly, MSRV, and latest stable
-        toolchain: [nightly, 1.72.0, 1.82.0]
+        toolchain: [nightly, 1.77.0, 1.88.0]
     runs-on: ubuntu-latest
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.
@@ -37,7 +37,7 @@ jobs:
 
       - name: Pin crates to versions for MSRV
         run: |
-          [[ ${{ matrix.toolchain }} != 1.72.0 ]] || (cargo update -p boring --precise 4.13.0 && cargo update -p litemap --precise 0.7.4 && cargo update -p zerofrom --precise 0.1.5 && cargo update -p half --precise 2.4.1)
+          [[ ${{ matrix.toolchain }} != 1.77.0 ]] || (cargo update -p boring --precise 4.13.0 && cargo update -p litemap --precise 0.7.4 && cargo update -p zerofrom --precise 0.1.5 && cargo update -p half --precise 2.4.1)
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
@@ -52,12 +52,12 @@ jobs:
 
       - name: Run cargo clippy
         run: |
-          [[ ${{ matrix.toolchain }} != 1.82.0 ]] || cargo clippy --all-targets --all -- --allow=unknown-lints --deny=warnings
+          [[ ${{ matrix.toolchain }} != 1.86.0 ]] || cargo clippy --all-targets --all -- --allow=unknown-lints --deny=warnings
 
       - name: Run cargo audit
         run: |
-          [[ ${{ matrix.toolchain }} != 1.82.0 ]] || (cargo install cargo-audit && cargo audit)
+          [[ ${{ matrix.toolchain }} != 1.86.0 ]] || (cargo install cargo-audit && cargo audit)
 
       - name: Run cargo machete
         run: |
-          [[ ${{ matrix.toolchain }} != 1.82.0 ]] || (cargo install cargo-machete --version 0.7.0 && cargo machete)
+          [[ ${{ matrix.toolchain }} != 1.86.0 ]] || (cargo install cargo-machete --version 0.7.0 && cargo machete)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # nightly, MSRV, and latest stable
-        toolchain: [nightly, 1.77.0, 1.88.0]
+        toolchain: [nightly, 1.77.0, 1.86.0]
     runs-on: ubuntu-latest
     # Only run on "pull_request" event for external PRs. This is to avoid
     # duplicate builds for PRs created from internal branches.

--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -57,7 +57,7 @@ percent-encoding = "2.1"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 socket2 = { version = ">=0.4, <1.0.0", features = ["all"] }
 flate2 = { version = "1", features = ["zlib-ng"], default-features = false }
-sfv = "0.10.4"
+sfv = "0.11.0"
 rand = "0.8"
 ahash = { workspace = true }
 unicase = "2"

--- a/pingora-core/src/protocols/http/compression/mod.rs
+++ b/pingora-core/src/protocols/http/compression/mod.rs
@@ -413,16 +413,17 @@ fn parse_accept_encoding(accept_encoding: Option<&http::HeaderValue>, list: &mut
             return;
         }
         // properly parse AC header
-        match sfv::Parser::parse_list(ac.as_bytes()) {
+        match sfv::Parser::new(ac.as_bytes()).parse_list() {
             Ok(parsed) => {
                 for item in parsed {
                     if let sfv::ListEntry::Item(i) = item {
                         if let Some(s) = i.bare_item.as_token() {
                             // TODO: support q value
-                            let algorithm = Algorithm::from(s);
+                            let algorithm = Algorithm::from(s.as_str());
+
                             // ignore algorithms that we don't understand ignore
                             if algorithm != Algorithm::Other {
-                                list.push(Algorithm::from(s));
+                                list.push(Algorithm::from(s.as_str()));
                             }
                         }
                     }

--- a/pingora-core/src/protocols/http/compression/mod.rs
+++ b/pingora-core/src/protocols/http/compression/mod.rs
@@ -420,7 +420,6 @@ fn parse_accept_encoding(accept_encoding: Option<&http::HeaderValue>, list: &mut
                         if let Some(s) = i.bare_item.as_token() {
                             // TODO: support q value
                             let algorithm = Algorithm::from(s.as_str());
-
                             // ignore algorithms that we don't understand ignore
                             if algorithm != Algorithm::Other {
                                 list.push(Algorithm::from(s.as_str()));


### PR DESCRIPTION
I updated and pinned to v11 after I saw someone has already pinned to the last working version in unreleased code: https://github.com/cloudflare/pingora/commit/1c484cef86133b2bacbf2e65637537c5c9c9a365

Anyway, here it is, if you want to update to v11

`sfv` v11 requires a min rust version of 1.77.0

At the moment pingora is broken on install - https://github.com/cloudflare/pingora/issues/568