### PR TITLE
rustls TlsAcceptor allow using custom ResolvesServerCert on Listener

### DIFF
--- a/pingora-core/src/listeners/mod.rs
+++ b/pingora-core/src/listeners/mod.rs
@@ -73,10 +73,13 @@ impl TransportStackBuilder {
         #[cfg(windows)]
         let l4 = builder.listen().await?;
 
-        Ok(TransportStack {
-            l4,
-            tls: self.tls.take().map(|tls| Arc::new(tls.build())),
-        })
+        let tls = if let Some(tls) = self.tls.take() {
+            Some(Arc::new(tls.build()?))
+        } else {
+            None
+        };
+
+        Ok(TransportStack { l4, tls })
     }
 }
 

--- a/pingora-core/src/listeners/tls/boringssl_openssl/mod.rs
+++ b/pingora-core/src/listeners/tls/boringssl_openssl/mod.rs
@@ -116,11 +116,11 @@ impl TlsSettings {
         }
     }
 
-    pub(crate) fn build(self) -> Acceptor {
-        Acceptor {
+    pub(crate) fn build(self) -> Result<Acceptor> {
+        Ok(Acceptor {
             ssl_acceptor: self.accept_builder.build(),
             callbacks: self.callbacks,
-        }
+        })
     }
 }
 

--- a/pingora-core/src/listeners/tls/rustls/mod.rs
+++ b/pingora-core/src/listeners/tls/rustls/mod.rs
@@ -87,7 +87,7 @@ impl TlsSettings {
         self.set_alpn(ALPN::H2H1);
     }
 
-    fn set_alpn(&mut self, alpn: ALPN) {
+    pub fn set_alpn(&mut self, alpn: ALPN) {
         self.alpn_protocols = Some(alpn.to_wire_protocols());
     }
 
@@ -106,10 +106,9 @@ impl TlsSettings {
     where
         Self: Sized,
     {
-        // TODO: verify if/how callback in handshake can be done using Rustls
         Error::e_explain(
             InternalError,
-            "Certificate callbacks are not supported with feature \"rustls\".",
+            "Certificate callbacks are not supported when using rustls.",
         )
     }
 }

--- a/pingora-core/src/protocols/tls/noop_tls/mod.rs
+++ b/pingora-core/src/protocols/tls/noop_tls/mod.rs
@@ -80,8 +80,8 @@ pub mod listeners {
     pub struct TlsSettings;
 
     impl TlsSettings {
-        pub fn build(&self) -> Acceptor {
-            Acceptor
+        pub fn build(&self) -> Result<Acceptor> {
+            Ok(Acceptor)
         }
 
         pub fn intermediate(_: &str, _: &str) -> Result<Self> {

--- a/pingora-rustls/src/lib.rs
+++ b/pingora-rustls/src/lib.rs
@@ -24,6 +24,7 @@ use std::path::Path;
 use log::warn;
 pub use no_debug::{Ellipses, NoDebug, WithTypeInfo};
 use pingora_error::{Error, ErrorType, OrErr, Result};
+pub use rustls::crypto::aws_lc_rs::default_provider;
 pub use rustls::{version, ClientConfig, RootCertStore, ServerConfig, Stream};
 pub use rustls_native_certs::load_native_certs;
 use rustls_pemfile::Item;
@@ -33,9 +34,10 @@ pub use tokio_rustls::server::TlsStream as ServerTlsStream;
 pub use tokio_rustls::{Accept, Connect, TlsAcceptor, TlsConnector, TlsStream};
 
 pub mod cert_resolvers {
-    pub use rustls::server::ResolvesServerCert;
     pub use rustls::server::{AlwaysResolvesServerRawPublicKeys, ResolvesServerCertUsingSni};
+    pub use rustls::server::{ClientHello, ResolvesServerCert};
     pub use rustls::sign::{CertifiedKey, SingleCertAndKey};
+    pub use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 }
 
 /// Load the given file from disk as a buffered reader and use the pingora Error

--- a/pingora-rustls/src/lib.rs
+++ b/pingora-rustls/src/lib.rs
@@ -32,6 +32,12 @@ pub use tokio_rustls::client::TlsStream as ClientTlsStream;
 pub use tokio_rustls::server::TlsStream as ServerTlsStream;
 pub use tokio_rustls::{Accept, Connect, TlsAcceptor, TlsConnector, TlsStream};
 
+pub mod cert_resolvers {
+    pub use rustls::server::ResolvesServerCert;
+    pub use rustls::server::{AlwaysResolvesServerRawPublicKeys, ResolvesServerCertUsingSni};
+    pub use rustls::sign::{CertifiedKey, SingleCertAndKey};
+}
+
 /// Load the given file from disk as a buffered reader and use the pingora Error
 /// type instead of the std::io version
 fn load_file<P>(path: P) -> Result<BufReader<File>>


### PR DESCRIPTION
This PR allows to use a custom `dyn ResolvesServerCert` for the rustls `TlsAcceptor`.

The solution enables certificate resolution based on SNI (#594) and provides flexibility for certificate related topics like certificate reloads during runtime (#611).

Additionally some minor cleanups are part of the PR.