### PR TITLE
Fix dead code warning on mac

### DIFF
--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -323,7 +323,7 @@ mod tests {
     /// not indicative of real errors. This function will retry the peer/server
     /// in increasing intervals until it either succeeds in connecting or a long
     /// timeout expires (max 10sec)
-    #[cfg(unix)]
+    #[cfg_attr(not(target_os = "linux"), expect(dead_code))]
     async fn wait_for_peer<P>(peer: &P)
     where
         P: Peer + Send + Sync,


### PR DESCRIPTION
This function is not used on mac, marking it as `#[expect]` instead of `#[cfg]` because it is convenient to typecheck dead code.