### PR TITLE
Use bstr for formatting byte strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
 ]
 
 [workspace.dependencies]
+bstr = "1.12.0"
 tokio = "1"
 async-trait = "0.1.42"
 httparse = "1"

--- a/pingora-cache/Cargo.toml
+++ b/pingora-cache/Cargo.toml
@@ -23,6 +23,7 @@ pingora-header-serde = { version = "0.6.0", path = "../pingora-header-serde" }
 pingora-http = { version = "0.6.0", path = "../pingora-http" }
 pingora-lru = { version = "0.6.0", path = "../pingora-lru" }
 pingora-timeout = { version = "0.6.0", path = "../pingora-timeout" }
+bstr = { workspace = true }
 http = { workspace = true }
 indexmap = "1"
 once_cell = { workspace = true }

--- a/pingora-cache/src/put.rs
+++ b/pingora-cache/src/put.rs
@@ -363,6 +363,7 @@ mod test {
 
 mod parse_response {
     use super::*;
+    use bstr::ByteSlice;
     use bytes::BytesMut;
     use httparse::Status;
     use pingora_error::{
@@ -469,7 +470,7 @@ mod parse_response {
                     self.state = ParseState::Invalid(e);
                     return Error::e_because(
                         InvalidHTTPHeader,
-                        format!("buf: {:?}", String::from_utf8_lossy(&self.buf)),
+                        format!("buf: {:?}", self.buf.as_bstr()),
                         e,
                     );
                 }

--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -27,6 +27,7 @@ pingora-error = { version = "0.6.0", path = "../pingora-error" }
 pingora-timeout = { version = "0.6.0", path = "../pingora-timeout" }
 pingora-http = { version = "0.6.0", path = "../pingora-http" }
 pingora-rustls = { version = "0.6.0", path = "../pingora-rustls", optional = true }
+bstr = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "signal"] }
 futures = "0.3"
 async-trait = { workspace = true }

--- a/pingora-core/src/protocols/http/v1/body.rs
+++ b/pingora-core/src/protocols/http/v1/body.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bstr::ByteSlice;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use log::{debug, trace, warn};
 use pingora_error::{
@@ -356,9 +357,7 @@ impl BodyReader {
                                 existing_buf_end {}, buf: {:?}",
                             expecting_from_io,
                             existing_buf_end,
-                            String::from_utf8_lossy(
-                                &self.body_buf.as_ref().unwrap()[..existing_buf_end]
-                            )
+                            self.body_buf.as_ref().unwrap()[..existing_buf_end].as_bstr()
                         );
                         // partial chunk payload, will read more
                         if expecting_from_io >= existing_buf_end + 2 {

--- a/pingora-core/src/protocols/http/v1/client.rs
+++ b/pingora-core/src/protocols/http/v1/client.rs
@@ -14,6 +14,7 @@
 
 //! HTTP/1.x client session
 
+use bstr::ByteSlice;
 use bytes::{BufMut, Bytes, BytesMut};
 use http::{header, header::AsHeaderName, HeaderValue, StatusCode, Version};
 use log::{debug, trace};
@@ -308,7 +309,7 @@ impl HttpSession {
                 HeaderParseState::Invalid(e) => {
                     return Error::e_because(
                         InvalidHTTPHeader,
-                        format!("buf: {}", String::from_utf8_lossy(&buf).escape_default()),
+                        format!("buf: {:?}", buf.as_bstr()),
                         e,
                     );
                 }

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -14,6 +14,7 @@
 
 //! HTTP/1.x server session
 
+use bstr::ByteSlice;
 use bytes::Bytes;
 use bytes::{BufMut, BytesMut};
 use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
@@ -284,10 +285,7 @@ impl HttpSession {
                                 buf.truncate(MAX_ERR_BUF_LEN);
                                 return Error::e_because(
                                     InvalidHTTPHeader,
-                                    format!(
-                                        "buf: {}",
-                                        String::from_utf8_lossy(&buf).escape_default()
-                                    ),
+                                    format!("buf: {:?}", buf.as_bstr()),
                                     e,
                                 );
                             }
@@ -297,7 +295,7 @@ impl HttpSession {
                             buf.truncate(MAX_ERR_BUF_LEN);
                             return Error::e_because(
                                 InvalidHTTPHeader,
-                                format!("buf: {}", String::from_utf8_lossy(&buf).escape_default()),
+                                format!("buf: {:?}", buf.as_bstr()),
                                 e,
                             );
                         }


### PR DESCRIPTION
Saw this in logs:

```
2025-08-16T11:11:42.859488Z ERROR ThreadId(36) pingora_proxy: /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pingora-proxy-0.5.0/src/lib.rs:148: Fail to proxy: Downstream InvalidHTTPHeader context: buf: \u{16}\u{3}\u{1}\u{0}\u{fffd}\u{1}\u{0}\u{0}\u{fffd}\u{3}\u{3}\u{fffd}\u{17}\u{b}0\u{fffd}!\u{fffd}T\u{fffd}\u{fffd}\u{b}\u{fffd}\u{1e}\u{fffd}\u{fffd}\u{fffd}i\u{2e4}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}BD\u{12}k m\u{fffd}&:\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{14}\u{fffd}]\u{fffd}?\u{7a4}a\u{fffd}\u{1f}\u{fffd}m\u{fffd}\u{1c}L\u{c}I\u{fffd}\u{14}N\u{fffd}\u{fffd}\u{0}&\u{328}\u{329}\u{fffd}/\u{fffd}0\u{fffd}+\u{fffd},\u{fffd}\u{13}\u{fffd}\t\u{fffd}\u{14}\u{fffd}\n\u{0}\u{fffd}\u{0}\u{fffd}\u{0}/\u{0}5\u{fffd}\u{12}\u{0}\n\u{13}\u{3}\u{13}\u{1}\u{13}\u{2}\u{1}\u{0}\u{0}{\u{0}\u{5}\u{0}\u{5}\u{1}\u{0}\u{0}\u{0}\u{0}\u{0}\n\u{0}\n\u{0}\u{8}\u{0}\u{1d}\u{0}\u{17}\u{0}\u{18}\u{0}\u{19}\u{0}\u{b}\u{0}\u{2}\u{1}\u{0}\u{0}\r\u{0}\u{1a}\u{0}\u{18}\u{8}\u{4}\u{4}\u{3}\u{8}\u{7}\u{8}\u{5}\u{8}\u{6}\u{4}\u{1}\u{5}\u{1}\u{6}\u{1}\u{5}\u{3}\u{6}\u{3}\u{2}\u{1}\u{2}\u{3}\u{fffd}\u{1}\u{0}\u{1}\u{0}\u{0}\u{12}\u{0}\u{0}\u{0}+\u{0}\t\u{8}\u{3}\u{4}\u{3}\u{3}\u{3}\u{2}\u{3}\u{1}\u{0}3\u{0}&\u{0}$\u{0}\u{1d}\u{0} \u{e}\u{fffd}\u{fffd}Q\u{f}\u{fffd}\u{fffd}\u{fffd}\u{79bc}:\u{fffd}\r\u{fffd}\u{fffd}\\\u{fffd}\u{c}\u{fffd}E\u{7f}\u{fffd}b\u{fffd}\u{fffd}\u{fffd}H\u{fffd}HHz cause: invalid token
```

There are two issues here:
- it is too verbose
- it is lossy (which might help if we need to actually decode these bytes)

`bstr` crate is designed to [print such strings](https://docs.rs/bstr/1.12.0/src/bstr/impls.rs.html#521-549), it prefers `\xNN`. It is popular crate developed by a person known in Rust community, so this dependency should be fine.