### PR TITLE
bug: basic peer error handling

### DIFF
--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -347,7 +347,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_conn_error_refused() {
-        let peer = BasicPeer::new("127.0.0.1:79"); // hopefully port 79 is not used
+        let peer = match BasicPeer::new("127.0.0.1:79") {
+            Ok(p) => p,
+            Err(e) => panic!("Failed to create peer: {e}"),
+        }; // hopefully port 79 is not used
         let new_session = connect(&peer, None).await;
         assert_eq!(new_session.unwrap_err().etype(), &ConnectRefused)
     }
@@ -356,7 +359,10 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn test_conn_error_no_route() {
-        let peer = BasicPeer::new("[::3]:79"); // no route
+        let peer = match BasicPeer::new("[::3]:79") {
+            Ok(p) => p,
+            Err(e) => panic!("Failed to create peer: {e}"),
+        }; // no route
         let new_session = connect(&peer, None).await;
         assert_eq!(new_session.unwrap_err().etype(), &ConnectNoRoute)
     }
@@ -391,7 +397,10 @@ mod tests {
     #[tokio::test]
     async fn test_conn_timeout() {
         // 192.0.2.1 is effectively a blackhole
-        let mut peer = BasicPeer::new("192.0.2.1:79");
+        let mut peer = match BasicPeer::new("192.0.2.1:79") {
+            Ok(p) => p,
+            Err(e) => panic!("Failed to create peer: {e}"),
+        };
         peer.options.connection_timeout = Some(std::time::Duration::from_millis(1)); //1ms
         let new_session = connect(&peer, None).await;
         assert_eq!(new_session.unwrap_err().etype(), &ConnectTimedout)
@@ -403,7 +412,10 @@ mod tests {
 
         let flag = Arc::new(AtomicBool::new(INIT_FLAG));
 
-        let mut peer = BasicPeer::new("1.1.1.1:80");
+        let mut peer = match BasicPeer::new("1.1.1.1:80") {
+            Ok(p) => p,
+            Err(e) => panic!("Failed to create peer: {e}"),
+        };
 
         let move_flag = Arc::clone(&flag);
 
@@ -431,7 +443,10 @@ mod tests {
             }
         }
         // :79 shouldn't be able to be connected to
-        let mut peer = BasicPeer::new("1.1.1.1:79");
+        let mut peer = match BasicPeer::new("1.1.1.1:79") {
+            Ok(p) => p,
+            Err(e) => panic!("Failed to create peer: {e}"),
+        };
         peer.options.custom_l4 = Some(std::sync::Arc::new(MyL4 {}));
 
         let new_session = connect(&peer, None).await;

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -227,9 +227,15 @@ pub struct BasicPeer {
 
 impl BasicPeer {
     /// Create a new [`BasicPeer`].
-    pub fn new(address: &str) -> Self {
-        let addr = SocketAddr::Inet(address.parse().unwrap()); // TODO: check error
-        Self::new_from_sockaddr(addr)
+    pub fn new(address: &str) -> Result<Self> {
+        let addr = match address.parse() {
+            Ok(v) => v,
+            Err(_) => {
+                panic!()
+            }
+        };
+        let addr = SocketAddr::Inet(addr);
+        Ok(Self::new_from_sockaddr(addr))
     }
 
     /// Create a new [`BasicPeer`] with the given path to a Unix domain socket.

--- a/pingora-load-balancing/src/health_check.rs
+++ b/pingora-load-balancing/src/health_check.rs
@@ -84,7 +84,13 @@ pub struct TcpHealthCheck {
 
 impl Default for TcpHealthCheck {
     fn default() -> Self {
-        let mut peer_template = BasicPeer::new("0.0.0.0:1");
+        let mut peer_template = match BasicPeer::new("0.0.0.0:1") {
+            Ok(peer) => peer,
+            Err(e) => {
+                // NB(@siennathesane): not sure what the desired behavior here is
+                panic!("Failed to create TCP peer template: {e}");
+            }
+        };
         peer_template.options.connection_timeout = Some(Duration::from_secs(1));
         TcpHealthCheck {
             consecutive_success: 1,

--- a/pingora/examples/service/proxy.rs
+++ b/pingora/examples/service/proxy.rs
@@ -18,7 +18,13 @@ use pingora_core::services::listening::Service;
 use pingora_core::upstreams::peer::BasicPeer;
 
 pub fn proxy_service(addr: &str, proxy_addr: &str) -> Service<ProxyApp> {
-    let proxy_to = BasicPeer::new(proxy_addr);
+    let proxy_to = match BasicPeer::new(proxy_addr) {
+        Ok(peer) => peer,
+        Err(e) => {
+            eprintln!("Failed to create proxy peer: {}", e);
+            std::process::exit(1);
+        }
+    };
 
     Service::with_listeners(
         "Proxy Service".to_string(),
@@ -34,7 +40,13 @@ pub fn proxy_service_tls(
     cert_path: &str,
     key_path: &str,
 ) -> Service<ProxyApp> {
-    let mut proxy_to = BasicPeer::new(proxy_addr);
+    let mut proxy_to = match BasicPeer::new(proxy_addr) {
+        Ok(peer) => peer,
+        Err(e) => {
+            eprintln!("Failed to create proxy peer: {}", e);
+            std::process::exit(1);
+        }
+    };
     // set SNI to enable TLS
     proxy_to.sni = proxy_sni.into();
     Service::with_listeners(


### PR DESCRIPTION
I ran into the `TODO` in `BasicPeer::new` so I implemented a rudimentary fix for it. It should have all the same behaviors but now exposes the result for upstream consumers.