### PR TITLE
fix(sec): bump prometheus to fix securit vulnerability

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -44,7 +44,7 @@ strum = "0.26.2"
 strum_macros = "0.26.2"
 libc = "0.2.70"
 chrono = { version = "~0.4.31", features = ["alloc"], default-features = false }
-prometheus = "0.13"
+prometheus = "0.14"
 sentry = { version = "0.36", features = [
     "backtrace",
     "contexts",


### PR DESCRIPTION
I noticed this downstream:

```
crate-audit> Crate:     protobuf
crate-audit> Version:   2.28.0
crate-audit> Title:     Crash due to uncontrolled recursion in protobuf crate
crate-audit> Date:      2024-12-12
crate-audit> ID:        RUSTSEC-2024-0437
crate-audit> URL:       https://rustsec.org/advisories/RUSTSEC-2024-0437
crate-audit> Solution:  Upgrade to >=3.7.2
crate-audit> Dependency tree:
crate-audit> protobuf 2.28.0
crate-audit> └── prometheus 0.13.4
crate-audit>     └── pingora-core 0.6.0
```

This is already fixed upstream in `prometheus`. We just need to bump the version here to include the fix, no further actions need to be taken.

---

Also: Would it be possible to make a patch release after the PR has been merged?