### PR TITLE
Add clru bench with pingora-lru, lru

### DIFF
--- a/pingora-lru/Cargo.toml
+++ b/pingora-lru/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8"
 [dev-dependencies]
 lru = { workspace = true }
 clru = "0.6.2"
+schnellru = "0.2.4"
 
 [[bench]]
 name = "bench_linked_list"


### PR DESCRIPTION
With MacOS M1-MAX chip:

```text
lru promote total 134.547375ms, 26ns avg per operation
clru promote total 230.315042ms, 46ns avg per operation
slru promote total 122.893584ms, 24ns avg per operation
pingora lru promote total 138.080833ms, 27ns avg per operation
pingora lru promote_top_10 total 116.681125ms, 23ns avg per operation
lru promote total 2.00903075s, 401ns avg per operation thread 0
lru promote total 2.022869875s, 404ns avg per operation thread 1
lru promote total 2.023443417s, 404ns avg per operation thread 3
lru promote total 2.026376667s, 405ns avg per operation thread 5
lru promote total 2.031932917s, 406ns avg per operation thread 4
lru promote total 2.032363542s, 406ns avg per operation thread 2
lru promote total 2.035749541s, 407ns avg per operation thread 7
lru promote total 2.036818541s, 407ns avg per operation thread 6
clru promote total 3.114593042s, 622ns avg per operation thread 2
clru promote total 3.128126417s, 625ns avg per operation thread 5
clru promote total 3.130462792s, 626ns avg per operation thread 1
clru promote total 3.133908708s, 626ns avg per operation thread 4
clru promote total 3.134992875s, 626ns avg per operation thread 3
clru promote total 3.140619292s, 628ns avg per operation thread 7
clru promote total 3.142404375s, 628ns avg per operation thread 0
clru promote total 3.14315725s, 628ns avg per operation thread 6
slru promote total 1.967431375s, 393ns avg per operation thread 2
slru promote total 1.967681833s, 393ns avg per operation thread 6
slru promote total 1.970550916s, 394ns avg per operation thread 5
slru promote total 1.977976917s, 395ns avg per operation thread 7
slru promote total 1.981461084s, 396ns avg per operation thread 0
slru promote total 1.982174125s, 396ns avg per operation thread 1
slru promote total 1.9866005s, 397ns avg per operation thread 4
slru promote total 1.987112042s, 397ns avg per operation thread 3
pingora lru promote total 1.7891155s, 357ns avg per operation thread 4
pingora lru promote total 1.790329958s, 358ns avg per operation thread 2
pingora lru promote total 1.797558542s, 359ns avg per operation thread 5
pingora lru promote total 1.799100791s, 359ns avg per operation thread 6
pingora lru promote total 1.799585584s, 359ns avg per operation thread 7
pingora lru promote total 1.800614125s, 360ns avg per operation thread 1
pingora lru promote total 1.801047625s, 360ns avg per operation thread 3
pingora lru promote total 1.801501208s, 360ns avg per operation thread 0
pingora lru promote_top_10 total 1.042270542s, 208ns avg per operation thread 4
pingora lru promote_top_10 total 1.04645725s, 209ns avg per operation thread 2
pingora lru promote_top_10 total 1.0509s, 210ns avg per operation thread 5
pingora lru promote_top_10 total 1.05135625s, 210ns avg per operation thread 1
pingora lru promote_top_10 total 1.053686s, 210ns avg per operation thread 0
pingora lru promote_top_10 total 1.055077625s, 211ns avg per operation thread 6
pingora lru promote_top_10 total 1.055832458s, 211ns avg per operation thread 7
pingora lru promote_top_10 total 1.05602s, 211ns avg per operation thread 3
```