### PR TITLE
Fix shutdown sleeping twice for graceful timeout

### DIFF
--- a/pingora-core/src/server/mod.rs
+++ b/pingora-core/src/server/mod.rs
@@ -578,7 +578,6 @@ impl Server {
                 info!("Waiting for runtimes to exit!");
                 let join = thread::spawn(move || {
                     rt.shutdown_timeout(shutdown_timeout);
-                    thread::sleep(shutdown_timeout)
                 });
                 (join, name)
             })


### PR DESCRIPTION
The shutdown_timeout call already waits up to the timeout duration. The additional sleep causes shutdown to always wait for the full timeout period even when runtimes exit early.

Fixes #727