### PR TITLE
Strip hop-by-hop headers in H1 upstream proxy

### DIFF
--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -36,6 +36,16 @@ impl<SV> HttpProxy<SV> {
 
         let mut req = session.req_header().clone();
 
+        // Strip hop-by-hop headers per RFC 2616 Section 13.5.1
+        req.remove_header(&http::header::CONNECTION);
+        req.remove_header("keep-alive");
+        req.remove_header("proxy-connection");
+        req.remove_header(&http::header::PROXY_AUTHENTICATE);
+        req.remove_header(&http::header::PROXY_AUTHORIZATION);
+        req.remove_header(&http::header::TE);
+        req.remove_header("trailer");
+        req.remove_header(&http::header::UPGRADE);
+
         // Convert HTTP2 headers to H1
         if req.version == Version::HTTP_2 {
             req.set_version(Version::HTTP_11);

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -38,8 +38,8 @@ impl<SV> HttpProxy<SV> {
 
         // Strip hop-by-hop headers per RFC 2616 Section 13.5.1
         // Exception: preserve Connection and Upgrade headers for websocket upgrades
-        let is_upgrade = req.version == Version::HTTP_11
-            && req.headers.get(&http::header::UPGRADE).is_some();
+        let is_upgrade =
+            req.version == Version::HTTP_11 && req.headers.get(&http::header::UPGRADE).is_some();
 
         if !is_upgrade {
             req.remove_header(&http::header::CONNECTION);


### PR DESCRIPTION
Per RFC 2616 Section 13.5.1, proxies must not forward hop-by-hop headers to upstream servers. This change adds header stripping for the H1 proxy path, matching the behavior already implemented for H2.

Headers stripped:
- Connection
- Keep-Alive
- Proxy-Connection
- Proxy-Authenticate
- Proxy-Authorization
- TE
- Trailer
- Upgrade

Fixes #706