### PR TITLE
Replace unmaintained daemonize with cf-daemonize

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -72,7 +72,7 @@ ouroboros = { version = "0.18.4", optional = true }
 lru = { version = "0.16.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-daemonize = "0.5.0"
+cf-daemonize = "0.3.0"
 nix = "~0.24.3"
 
 [target.'cfg(windows)'.dependencies]

--- a/pingora-core/src/server/daemon.rs
+++ b/pingora-core/src/server/daemon.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cf_daemonize::{Daemonize, Stdio};
+use cf_daemonize::Daemonize;
 use log::{debug, error};
 use std::ffi::CString;
 use std::fs::{self, OpenOptions};

--- a/pingora-core/src/server/daemon.rs
+++ b/pingora-core/src/server/daemon.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use daemonize::{Daemonize, Stdio};
+use cf_daemonize::{Daemonize, Stdio};
 use log::{debug, error};
 use std::ffi::CString;
 use std::fs::{self, OpenOptions};
@@ -75,7 +75,7 @@ pub fn daemonize(conf: &ServerConf) {
             .unwrap();
         daemonize.stderr(err)
     } else {
-        daemonize.stdout(Stdio::keep()).stderr(Stdio::keep())
+        daemonize
     };
 
     let daemonize = match conf.user.as_ref() {


### PR DESCRIPTION
The daemonize crate is unmaintained and has a security advisory (RUSTSEC-2025-0069). This switches to cf-daemonize, a Cloudflare fork with the same API.

Changes:
- Update Cargo.toml to use cf-daemonize 0.3.0
- Update import from daemonize to cf_daemonize
- Remove Stdio::keep() calls (not available in cf-daemonize 0.3.0)
  Daemon preserves stdio by default when not explicitly configured

Fixes #699

Note: cf-daemonize has future incompatibility warnings. Maintainers may want to consider alternatives like daemonize-me or implementing a custom solution.