### PR TITLE
Export ResponseHeader in prelude for API consistency

### DIFF
--- a/pingora-http/src/lib.rs
+++ b/pingora-http/src/lib.rs
@@ -42,7 +42,7 @@ use case_header_name::CaseHeaderName;
 pub use case_header_name::IntoCaseHeaderName;
 
 pub mod prelude {
-    pub use crate::RequestHeader;
+    pub use crate::{RequestHeader, ResponseHeader};
 }
 
 /* an ordered header map to store the original case of each header name


### PR DESCRIPTION
RequestHeader is exported in the prelude but ResponseHeader is not, causing an inconsistency. Users need to explicitly import ResponseHeader while RequestHeader is available through the prelude.

This change adds ResponseHeader to the prelude exports for consistency.

Fixes #551