### PR TITLE
Fix flaky test_eviction test

### DIFF
--- a/pingora-memory-cache/src/lib.rs
+++ b/pingora-memory-cache/src/lib.rs
@@ -320,9 +320,9 @@ mod tests {
     #[test]
     fn test_eviction() {
         let cache: MemoryCache<i32, i32> = MemoryCache::new(2);
-        cache.put(&1, 2, None);
-        cache.put(&2, 4, None);
-        cache.put(&3, 6, None);
+        cache.force_put(&1, 2, None);
+        cache.force_put(&2, 4, None);
+        cache.force_put(&3, 6, None);
         let (res, hit) = cache.get(&1);
         assert_eq!(res, None);
         assert_eq!(hit, CacheStatus::Miss);


### PR DESCRIPTION
Fixes #591

Use force_put instead of put to ensure items are inserted regardless of TinyLFU admission policy.