### PR TITLE
Add path rewriting helpers to RequestHeader

### DIFF
--- a/pingora-http/src/lib.rs
+++ b/pingora-http/src/lib.rs
@@ -371,7 +371,10 @@ impl RequestHeader {
             let new_path = if stripped.is_empty() || stripped.starts_with('/') {
                 stripped
             } else {
-                return Err(pingora_error::Error::explain(InvalidHTTPHeader, "prefix must end with / or match full path"));
+                return Err(pingora_error::Error::explain(
+                    InvalidHTTPHeader,
+                    "prefix must end with / or match full path",
+                ));
             };
             self.set_path(new_path)?;
             Ok(true)


### PR DESCRIPTION
Fixes #462

Adds two helper methods for path rewriting:
- set_path() - rewrite path preserving query string
- strip_path_prefix() - strip prefix from path