### PR TITLE
feat: Add new_mtls for HttpProxy

### DIFF
--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -642,6 +642,17 @@ impl HttpPeer {
         }
     }
 
+    /// Create a new [`HttpPeer`] with client certificate and key for mutual TLS.
+    pub fn new_mtls<A: ToInetSocketAddrs>(
+        address: A,
+        sni: String,
+        client_cert_key: Arc<CertKey>,
+    ) -> Self {
+        let mut peer = Self::new(address, true, sni);
+        peer.client_cert_key = Some(client_cert_key);
+        peer
+    }
+
     fn peer_hash(&self) -> u64 {
         let mut hasher = AHasher::default();
         self.hash(&mut hasher);


### PR DESCRIPTION
Tiny fix to resolve #783 

We expose a `new_mtls` method for creating a HttpProxy with a client_cert_key to enable mTLS peers.

AFAIK there is currently no other way to set or modify the client_cert_key field. So that small change enables to actually use mTLS HttpPeers, even if the foundations (with the field) been there for a while...

This works well for my own usecase!

Let me know if anyone prefers another approach, i.e a public setter instead of constructor. Or just a different name.
Also, looking at some previous commits it doesnt feel like this sort of changes requires tests to be written. But let me know if thats a wrong assumption.

For anyone looking to use mTLS with a self signed server certificate will you need to modify the PeerOptions too.
Here is an example from my own project:
```rust
let mut peer = Box::new(HttpPeer::new_mtls(
    target.address.to_string(),
    target.sni.clone(),
    target.client_cert.clone(),
));
let peer_options = peer.get_mut_peer_options().unwrap();
peer_options.ca = Some(target.ca.clone());
```