### PR TITLE
Supporting smaller TCP_INFO shapes optionally relaxing get_opt_sized response validation with strict flag

### DIFF
--- a/pingora-core/src/protocols/l4/ext.rs
+++ b/pingora-core/src/protocols/l4/ext.rs
@@ -146,16 +146,17 @@ fn get_opt<T>(
     }
 }
 
-// allow_smaller: exact size checks reject older kernels that return shorter, versioned structs;
-// allowing smaller means the tail stays zeroed and those fields may be “absent,” not real zeros.
+// strict: strict validation enforces exact size checks on returned objects kernels.
+// passing 'false' for strict relaxes validation to allow the kernel to send smaller objects than the size of T.
+// allowing smaller size values means the tail stays zeroed and those fields may be “absent,” not real zeros.
 #[cfg(target_os = "linux")]
-fn get_opt_sized<T>(sock: c_int, opt: c_int, val: c_int, allow_smaller: bool) -> io::Result<T> {
+fn get_opt_sized<T>(sock: c_int, opt: c_int, val: c_int, strict: bool) -> io::Result<T> {
     let mut payload = mem::MaybeUninit::zeroed();
     let expected_size = mem::size_of::<T>() as socklen_t;
     let mut size = expected_size;
     get_opt(sock, opt, val, &mut payload, &mut size)?;
 
-    if size > expected_size || (!allow_smaller && size != expected_size) {
+    if size > expected_size || (strict && size != expected_size) {
         return Err(std::io::Error::other("get_opt size mismatch"));
     }
     // Assume getsockopt() will set the value properly
@@ -274,7 +275,7 @@ fn set_keepalive(_sock: RawSocket, _ka: &TcpKeepalive) -> io::Result<()> {
 /// Get the kernel TCP_INFO for the given FD.
 #[cfg(target_os = "linux")]
 pub fn get_tcp_info(fd: RawFd) -> io::Result<TCP_INFO> {
-    get_opt_sized(fd, libc::IPPROTO_TCP, libc::TCP_INFO, true)
+    get_opt_sized(fd, libc::IPPROTO_TCP, libc::TCP_INFO, false)
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
@@ -306,7 +307,7 @@ pub fn set_recv_buf(_sock: RawSocket, _: usize) -> Result<()> {
 
 #[cfg(target_os = "linux")]
 pub fn get_recv_buf(fd: RawFd) -> io::Result<usize> {
-    get_opt_sized::<c_int>(fd, libc::SOL_SOCKET, libc::SO_RCVBUF, false).map(|v| v as usize)
+    get_opt_sized::<c_int>(fd, libc::SOL_SOCKET, libc::SO_RCVBUF, true).map(|v| v as usize)
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
@@ -321,7 +322,7 @@ pub fn get_recv_buf(_sock: RawSocket) -> io::Result<usize> {
 
 #[cfg(target_os = "linux")]
 pub fn get_snd_buf(fd: RawFd) -> io::Result<usize> {
-    get_opt_sized::<c_int>(fd, libc::SOL_SOCKET, libc::SO_SNDBUF, false).map(|v| v as usize)
+    get_opt_sized::<c_int>(fd, libc::SOL_SOCKET, libc::SO_SNDBUF, true).map(|v| v as usize)
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
@@ -405,7 +406,7 @@ pub fn set_dscp(_sock: RawSocket, _value: u8) -> Result<()> {
 
 #[cfg(target_os = "linux")]
 pub fn get_socket_cookie(fd: RawFd) -> io::Result<u64> {
-    get_opt_sized::<c_ulonglong>(fd, libc::SOL_SOCKET, libc::SO_COOKIE, false)
+    get_opt_sized::<c_ulonglong>(fd, libc::SOL_SOCKET, libc::SO_COOKIE, true)
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
@@ -426,7 +427,7 @@ pub fn get_original_dest(fd: RawFd) -> Result<Option<SocketAddr>> {
         .or_err(SocketError, "failed get original dest, invalid IP socket")?;
 
     let dest = if addr.is_ipv4() {
-        get_opt_sized::<libc::sockaddr_in>(fd, libc::SOL_IP, libc::SO_ORIGINAL_DST, false).map(
+        get_opt_sized::<libc::sockaddr_in>(fd, libc::SOL_IP, libc::SO_ORIGINAL_DST, true).map(
             |addr| {
                 SocketAddr::V4(SocketAddrV4::new(
                     u32::from_be(addr.sin_addr.s_addr).into(),
@@ -435,7 +436,7 @@ pub fn get_original_dest(fd: RawFd) -> Result<Option<SocketAddr>> {
             },
         )
     } else {
-        get_opt_sized::<libc::sockaddr_in6>(fd, libc::SOL_IPV6, libc::IP6T_SO_ORIGINAL_DST, false)
+        get_opt_sized::<libc::sockaddr_in6>(fd, libc::SOL_IPV6, libc::IP6T_SO_ORIGINAL_DST, true)
             .map(|addr| {
                 SocketAddr::V6(SocketAddrV6::new(
                     addr.sin6_addr.s6_addr.into(),


### PR DESCRIPTION
### Summary

Relax `getsockopt` size checking for TCP_INFO whose struct ABI can vary across kernel versions.

### Motivation

Some kernel socket options return versioned, kernel-defined structs whose size has grown over time. Older kernels legitimately return fewer bytes and update optlen accordingly, causing strict size == sizeof(T) checks to fail even though the returned data is valid. The problem here is inaccessibility of `TCP_INFO` from `pingora` on certain kernel versions.

### Change

- Add an strict flag to get_opt_sized
- Continue enforcing exact size for fixed-size options, allowing shorter returns only when explicitly opted in by passing strict as false.
- Opting `TCP_INFO` into this new behavior.
- Preserve safety by rejecting any size > sizeof(T)

### Notes

When smaller sizes are allowed, zeroed fields may indicate that a field is absent rather than a true zero value. Note that this ambiguity can already exist today: a matching struct size does not guarantee that the kernel provides the same set of fields as the userspace` TCP_INFO` definition.