### PR TITLE
feat: add support for client certificate verification in mTLS configu…

### DIFF
--- a/pingora-rustls/src/lib.rs
+++ b/pingora-rustls/src/lib.rs
@@ -25,6 +25,8 @@ use log::warn;
 pub use no_debug::{Ellipses, NoDebug, WithTypeInfo};
 use pingora_error::{Error, ErrorType, OrErr, Result};
 
+pub use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+pub use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
 pub use rustls::{
     client::WebPkiServerVerifier, version, CertificateError, ClientConfig, DigitallySignedStruct,
     Error as RusTlsError, RootCertStore, ServerConfig, SignatureScheme, Stream,


### PR DESCRIPTION

This PR adds a public hook to configure a custom rustls ClientCertVerifier for server-side TLS listeners. fix #791 

The change introduces:
- An optional `client_cert_verifier` field on rustls `TlsSettings`
- A public setter to inject `Arc<dyn ClientCertVerifier>`
- Conditional wiring of `with_client_cert_verifier()` when a verifier is provided