### PR TITLE
Add pre-TLS processing hook for PROXY protocol support and expose methods for HTTP2 shutdown

### DIFF
--- a/pingora-core/src/listeners/mod.rs
+++ b/pingora-core/src/listeners/mod.rs
@@ -228,12 +228,12 @@ impl UninitializedStream {
     pub async fn handshake(mut self) -> Result<Stream> {
         self.l4.set_buffer();
 
-        // Process pre-TLS data if a callback is configured (e.g., PROXY protocol)
-        if let Some(ref callback) = self.pre_tls_callback {
-            callback.process(&mut self.l4).await?;
-        }
-
         if let Some(tls) = self.tls {
+            // Process pre-TLS data if a callback is configured (e.g., PROXY protocol)
+            if let Some(ref callback) = self.pre_tls_callback {
+                callback.process(&mut self.l4).await?;
+            }
+
             let tls_stream = tls.tls_handshake(self.l4).await?;
             Ok(Box::new(tls_stream))
         } else {

--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -437,6 +437,19 @@ impl Session {
         }
     }
 
+    /// Give up the H2 stream with a custom reason.
+    ///
+    /// For H2, this sends a `RST_STREAM` frame with the specified reason.
+    /// For H1, subrequests, and custom sessions, this is a no-op since they don't support
+    /// stream reset reasons.
+    ///
+    /// See [`super::v2::server::HttpSession::shutdown_with_reason`] for available reasons.
+    pub fn shutdown_with_reason(&mut self, reason: h2::Reason) {
+        if let Self::H2(s) = self {
+            s.shutdown_with_reason(reason);
+        }
+    }
+
     pub fn to_h1_raw(&self) -> Bytes {
         match self {
             Self::H1(s) => s.get_headers_raw_bytes(),

--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -465,10 +465,23 @@ impl HttpSession {
 
     /// Give up the stream abruptly.
     ///
-    /// This will send a `INTERNAL_ERROR` stream error to the client
+    /// This will send an `INTERNAL_ERROR` stream error to the client.
     pub fn shutdown(&mut self) {
+        self.shutdown_with_reason(h2::Reason::INTERNAL_ERROR);
+    }
+
+    /// Give up the stream abruptly with a custom reason.
+    ///
+    /// This will send a `RST_STREAM` frame with the given reason to the client.
+    ///
+    /// Useful reasons include:
+    /// - [`h2::Reason::HTTP_1_1_REQUIRED`] - Signal to the client that HTTP/1.1 should be used
+    ///   instead. Per RFC 7540 §9.1.2, clients should retry the request over HTTP/1.1.
+    /// - [`h2::Reason::CANCEL`] - Indicate the stream is no longer needed.
+    /// - [`h2::Reason::REFUSED_STREAM`] - Indicate the stream was refused before processing.
+    pub fn shutdown_with_reason(&mut self, reason: h2::Reason) {
         if !self.ended {
-            self.send_response.send_reset(h2::Reason::INTERNAL_ERROR);
+            self.send_response.send_reset(reason);
         }
     }
 

--- a/pingora-core/src/protocols/l4/stream.rs
+++ b/pingora-core/src/protocols/l4/stream.rs
@@ -445,8 +445,11 @@ impl Stream {
         Ok(())
     }
 
-    /// Put Some data back to the head of the stream to be read again
-    pub(crate) fn rewind(&mut self, data: &[u8]) {
+    /// Put some data back to the head of the stream to be read again.
+    ///
+    /// This is useful when you've read data to detect a protocol (e.g., PROXY protocol)
+    /// but the data wasn't what you expected, so you need to "unread" it.
+    pub fn rewind(&mut self, data: &[u8]) {
         if !data.is_empty() {
             self.rewind_read_buf.push(data.to_vec());
         }


### PR DESCRIPTION
This adds a `PreTlsProcess` trait and callback mechanism that allows applications to read and process bytes from the raw TCP stream before the TLS handshake begins. Provides a way to self-implement #132 .

This also exposes HTTP2 session terminators.  Closes #775.

The HAProxy PROXY protocol spec requires that the header be parsed from the raw TCP stream before any application protocol processing, including TLS. Currently there's no way to do this in Pingora - by the time `ServerApp::process_new` runs, TLS has already completed.
https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

This is how nginx and haproxy handle it: TCP accept → parse PROXY header → TLS handshake → HTTP.
https://github.com/nginx/nginx/blob/master/src/http/ngx_http_request.c#L307-L362

**Changes**
- Add `PreTlsProcess` trait in pingora-core/src/listeners/mod.rs
- Thread callback through TransportStackBuilder → TransportStack → UninitializedStream
- Call callback in `UninitializedStream::handshake()` before TLS
- Make `Stream::rewind()` public so implementations can put back bytes that aren't PROXY protocol

Usage

```
struct ProxyProtocolHandler;

#[async_trait]
impl PreTlsProcess for ProxyProtocolHandler {
    async fn process(&self, stream: &mut L4Stream) -> Result<()> {
        // Read PROXY header, update socket digest with real client IP
        Ok(())
    }
}

// In setup:
listeners.set_pre_tls_callback(Arc::new(ProxyProtocolHandler));
```

This code is being used in a beta server deployment with PROXY Protocol v1 and v2 support to handle incoming traffic from other web servers and Tor with success.