### PR TITLE
fix(windows): add missing `RawStream::Virtual` match arm in `AsRawSoc…

### DIFF
--- a/pingora-core/src/protocols/l4/stream.rs
+++ b/pingora-core/src/protocols/l4/stream.rs
@@ -150,6 +150,8 @@ impl AsRawSocket for RawStream {
     fn as_raw_socket(&self) -> std::os::windows::io::RawSocket {
         match self {
             RawStream::Tcp(s) => s.as_raw_socket(),
+            // Virtual stream does not have a real socket, return INVALID_SOCKET (!0)
+            RawStream::Virtual(_) => !0,
         }
     }
 }


### PR DESCRIPTION
## Summary

The `#[cfg(windows)] impl AsRawSocket for RawStream` in `pingora-core/src/protocols/l4/stream.rs` is missing a match arm for the `RawStream::Virtual(_)` variant, causing a compilation error (E0004: non-exhaustive patterns) on Windows targets.

The `Virtual` variant is defined without any `#[cfg]` gate and exists on all platforms. The Unix counterpart (`AsRawFd for RawStream`) already correctly handles this variant by returning `-1`.

## Fix

Added the missing match arm returning `!0` (`INVALID_SOCKET`) for virtual streams, consistent with the Unix implementation:

- Unix (existing, correct): `RawStream::Virtual(_) => -1`
- Windows (added): `RawStream::Virtual(_) => !0`

## Verification

- Confirmed this is the only `#[cfg(windows)]` match on `RawStream` missing the `Virtual` arm
- All other match expressions in `stream.rs` (AsyncRead, AsyncWrite, Drop, etc.) already handle `Virtual` correctly