### PR TITLE
docs: update quick start to Pingora 0.7 and fix missing openssl feature

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -19,7 +19,7 @@ cargo new load_balancer
 In your project's `cargo.toml` file add the following to your dependencies
 ```
 async-trait="0.1"
-pingora = { version = "0.3", features = [ "lb" ] }
+pingora = { version = "0.7", features = [ "lb", "openssl" ] }
 ```
 
 ### Create a pingora server


### PR DESCRIPTION
## Description
While following the `docs/quick_start.md` guide with Pingora 0.7, I encountered 502 Bad Gateway errors when the load balancer attempted to connect to HTTPS backends (1.1.1.1 / 1.0.0.1).

Investigation revealed that the `openssl` feature was missing, which is required for TLS connections.

This PR:
- Updates the `pingora` version in the example `Cargo.toml` from `0.3` to `0.7` to match the latest release.
- Adds the `"openssl"` feature to the `pingora` dependency to ensure HTTPS backends work correctly.

## Motivation
Running the quick start example exactly as documented resulted in 502 errors due to missing TLS support. This change ensures new users have a working example out of the box.