### PR TITLE
pingora-core: fix compile on windows

### DIFF
--- a/pingora-core/src/protocols/l4/stream.rs
+++ b/pingora-core/src/protocols/l4/stream.rs
@@ -150,6 +150,7 @@ impl AsRawSocket for RawStream {
     fn as_raw_socket(&self) -> std::os::windows::io::RawSocket {
         match self {
             RawStream::Tcp(s) => s.as_raw_socket(),
+            RawStream::Virtual(_) => u64::MAX, // Virtual stream does not have a real fd
         }
     }
 }


### PR DESCRIPTION
RawStream::Virtual variant was not handled in windows as_raw_socket, failing with `pattern &RawStream::Virtual(_) not covered`