### PR TITLE
Quickstart docs fix - pingora version number failing over v0.3

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -19,7 +19,8 @@ cargo new load_balancer
 In your project's `cargo.toml` file add the following to your dependencies
 ```
 async-trait="0.1"
-pingora = { version = "0.3", features = [ "lb" ] }
+pingora = { version = "0.7.0", features = ["openssl", "lb"] }
+
 ```
 
 ### Create a pingora server

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -19,7 +19,7 @@ cargo new load_balancer
 In your project's `cargo.toml` file add the following to your dependencies
 ```
 async-trait="0.1"
-pingora = { version = "0.7.0", features = ["openssl", "lb"] }
+pingora = { version = "0.8.0", features = ["openssl", "lb"] }
 
 ```
 

--- a/docs/user_guide/rate_limiter.md
+++ b/docs/user_guide/rate_limiter.md
@@ -5,8 +5,8 @@ Pingora provides a crate `pingora-limits` which provides a simple and easy to us
 1. Add the following dependencies to your `Cargo.toml`:
    ```toml
    async-trait="0.1"
-   pingora = { version = "0.7", features = [ "lb", "openssl" ] }
-   pingora-limits = "0.7.0"
+   pingora = { version = "0.8", features = [ "lb", "openssl" ] }
+   pingora-limits = "0.8.0"
    once_cell = "1.19.0"
    ```
 2. Declare a global rate limiter map to store the rate limiter for each client. In this example, we use `appid`.

--- a/docs/user_guide/rate_limiter.md
+++ b/docs/user_guide/rate_limiter.md
@@ -5,8 +5,8 @@ Pingora provides a crate `pingora-limits` which provides a simple and easy to us
 1. Add the following dependencies to your `Cargo.toml`:
    ```toml
    async-trait="0.1"
-   pingora = { version = "0.3", features = [ "lb" ] }
-   pingora-limits = "0.3.0"
+   pingora = { version = "0.7", features = [ "lb", "openssl" ] }
+   pingora-limits = "0.7.0"
    once_cell = "1.19.0"
    ```
 2. Declare a global rate limiter map to store the rate limiter for each client. In this example, we use `appid`.
@@ -20,6 +20,7 @@ Pingora provides a crate `pingora-limits` which provides a simple and easy to us
 ```rust
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
+use pingora::http::ResponseHeader;
 use pingora::prelude::*;
 use pingora_limits::rate::Rate;
 use std::sync::Arc;

--- a/pingora-proxy/examples/connection_filter.rs
+++ b/pingora-proxy/examples/connection_filter.rs
@@ -49,7 +49,7 @@ struct BlockAllFilter;
 
 #[async_trait]
 impl ConnectionFilter for BlockAllFilter {
-    async fn should_accept(&self, addr: &std::net::SocketAddr) -> bool {
+    fn should_accept(&self, addr: &std::net::SocketAddr) -> bool {
         info!("BLOCKING connection from {} (BlockAllFilter active)", addr);
         false
     }


### PR DESCRIPTION
Quickstart documentation uses v0.3, and suggests adding via:
```toml
async-trait="0.1"
pingora = { version = "0.3", features = [ "lb" ] }
``` 

If using any *later* version than v0.3 (i.e., v0.4...0.7) then the quick start example silently fails. ( as needs "openssl" feature)

<details>
<summary>Reproducing</summary>


```rust
use async_trait::async_trait;
use pingora::prelude::*;
use std::sync::Arc;

pub struct LB(Arc<LoadBalancer<RoundRobin>>);

#[async_trait]
impl ProxyHttp for LB {
    type CTX = ();
    fn new_ctx(&self) -> () {
        ()
    }
    async fn upstream_peer(&self, _session: &mut Session, _ctx: &mut ()) -> Result<Box<HttpPeer>> {
        let upstream = self
            .0
            .select(b"", 256) // hash doesn't matter for round robin
            .unwrap();

        println!("upstream peer is: {upstream:?}");

        // Set SNI to one.one.one.one
        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
        Ok(peer)
    }
    async fn upstream_request_filter(
        &self,
        _session: &mut Session,
        upstream_request: &mut RequestHeader,
        _ctx: &mut Self::CTX,
    ) -> Result<()> {
        upstream_request
            .insert_header("Host", "one.one.one.one")
            .unwrap();
        Ok(())
    }
}
fn main() {
    let mut my_server = Server::new(None).unwrap();
    my_server.bootstrap();

    let upstreams = LoadBalancer::try_from_iter(["1.1.1.1:443", "1.0.0.1:443"]).unwrap();

    let mut lb = http_proxy_service(&my_server.configuration, LB(Arc::new(upstreams)));
    lb.add_tcp("0.0.0.0:6188");

    my_server.add_service(lb);

    my_server.run_forever();
}

```
</details>
<details>
<summary> Expected results</summary>
Expected curl output as such:

<img width="1383" height="443" alt="Image" src="https://github.com/user-attachments/assets/1cea7a0e-dafa-49f5-a209-1556d8c18f14" />


## Observed results

<img width="1329" height="553" alt="Image" src="https://github.com/user-attachments/assets/474fa041-2c12-4a63-90c9-42c68a47fe15" />

Even running with RUST_LOG=TRACE no errors are logged.

<img width="1103" height="145" alt="Image" src="https://github.com/user-attachments/assets/3ff960d0-4828-40e6-a658-4bb62f158e49" />

</details>

<details>
<summary> More context </summary>


Upon using the quickstart docs, I saw that the latest release was 0.7.0 & decided to run:

```bash
cargo add pingora --features lb 
cargo add async-trait
``` 
which lead to:
```toml
# XXXXXXX
[dependencies]
async-trait = "0.1.89"
pingora = { version = "0.7.0", features = ["lb", "openssl"] }

```
</details>


My initial debugging lead me to #61 which assumes it's an intentional 502 as 127... ( a non-existent proxy) is used in the later example in quick start docs. 



## Solution 

Change quickstart docs to have:
```toml
pingora = { version = "0.7.0", features = ["lb", "openssl"] }
```
or 
```toml
pingora = { version = "0.3.0", features = ["lb", "openssl"] }
```

Admittedly this is a niche use-case, but seems like something that as realistically happened to others. 

```toml
pingora = { version = "0.3.0", features = ["lb"] }  # works

pingora = { version = "0.4.0", features = ["lb"] }  # doesn't work 
pingora = { version = "0.4.0", features = ["lb", "openssl"] }  # works

pingora = { version = "0.7.0", features = ["lb"] }  # doesn't work
pingora = { version = "0.7.0", features = ["lb", "openssl"]}  # works
```