### PR TITLE
ci: use cargo check for MSRV instead of cargo test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,17 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
+      - name: Run cargo check
+        run: cargo check --workspace
+
       - name: Run cargo test
+        if: matrix.toolchain != '1.84.0'
         run: cargo test --verbose --lib --bins --tests --no-fail-fast
 
       # Need to run doc tests separately.
       # (https://github.com/rust-lang/cargo/issues/6669)
       - name: Run cargo doc test
+        if: matrix.toolchain != '1.84.0'
         run: cargo test --verbose --doc
 
       - name: Run cargo clippy


### PR DESCRIPTION
## Summary

The MSRV (1.84.0) job fails because `cargo test` compiles dev-dependencies, and a transitive dev-dependency chain pulls in `cpufeatures v0.3.0` which uses `edition = "2024"` -- an edition that Cargo 1.84.0 cannot parse:

```
pingora-proxy [dev-dependencies]
  → tokio-tungstenite v0.20.1
    → tungstenite v0.20.1
      → sha1 v0.10.6
        → cpufeatures v0.3.0    ← edition = "2024", requires Cargo 1.85+
```

Run `cargo check --workspace` for all toolchains and skip `cargo test` on the MSRV.