### PR TITLE
feat: make rustls cert public

### DIFF
--- a/pingora-core/src/protocols/http/v2/server.rs
+++ b/pingora-core/src/protocols/http/v2/server.rs
@@ -808,6 +808,7 @@ mod test {
             assert_eq!(data, server_body);
 
             req_body.send_data("".into(), true).unwrap(); // set EOS after read the resp body
+            tokio::task::yield_now().await;
         }));
 
         let mut connection = handshake(Box::new(server), None).await.unwrap();
@@ -880,6 +881,7 @@ mod test {
             assert_eq!(data, server_body);
 
             req_body.send_data("".into(), true).unwrap(); // set EOS after read the resp body
+            tokio::task::yield_now().await;
         }));
 
         let mut connection = handshake(Box::new(server), None).await.unwrap();

--- a/pingora-core/src/utils/tls/rustls.rs
+++ b/pingora-core/src/utils/tls/rustls.rs
@@ -101,17 +101,17 @@ pub struct CertKey {
     certificates: Vec<WrappedX509>,
 }
 
-#[self_referencing]
+#[self_referencing(pub_extras)]
 #[derive(Debug)]
 pub struct WrappedX509 {
-    raw_cert: Vec<u8>,
+    pub raw_cert: Vec<u8>,
 
     #[borrows(raw_cert)]
     #[covariant]
-    cert: X509Certificate<'this>,
+    pub cert: X509Certificate<'this>,
 }
 
-fn parse_x509<C>(raw_cert: &C) -> X509Certificate<'_>
+pub fn parse_x509<C>(raw_cert: &C) -> X509Certificate<'_>
 where
     C: AsRef<[u8]>,
 {

--- a/pingora-core/src/utils/tls/rustls.rs
+++ b/pingora-core/src/utils/tls/rustls.rs
@@ -25,6 +25,8 @@ pub fn get_organization_serial(x509cert: &WrappedX509) -> Result<(Option<String>
     Ok((get_organization(x509cert), serial))
 }
 
+/// Extract the organization and serial from a raw [`X509Certificate`]
+/// reference.
 fn get_organization_serial_x509(
     x509cert: &X509Certificate<'_>,
 ) -> Result<(Option<String>, String)> {
@@ -111,7 +113,27 @@ pub struct WrappedX509 {
     pub cert: X509Certificate<'this>,
 }
 
-pub fn parse_x509<C>(raw_cert: &C) -> X509Certificate<'_>
+/// Fallible variant of certificate parsing for use with
+/// [`WrappedX509::try_new`].
+fn try_parse_x509<C>(raw_cert: &C) -> Result<X509Certificate<'_>>
+where
+    C: AsRef<[u8]>,
+{
+    X509Certificate::from_der(raw_cert.as_ref())
+        .map(|(_, cert)| cert)
+        .map_err(|e| {
+            pingora_error::Error::explain(
+                pingora_error::ErrorType::InternalError,
+                format!("failed to parse DER certificate: {e}"),
+            )
+        })
+}
+
+/// Infallible certificate parse; panics on invalid DER.
+///
+/// Kept for internal callers ([`CertKey::new`], [`Clone`]) that
+/// already guarantee valid input.
+fn parse_x509<C>(raw_cert: &C) -> X509Certificate<'_>
 where
     C: AsRef<[u8]>,
 {
@@ -178,6 +200,15 @@ impl CertKey {
 }
 
 impl WrappedX509 {
+    /// Parse DER-encoded certificate bytes into a [`WrappedX509`].
+    ///
+    /// Returns an error if the bytes are not a valid DER-encoded
+    /// X.509 certificate.
+    pub fn parse(raw_cert: Vec<u8>) -> Result<Self> {
+        Self::try_new(raw_cert, try_parse_x509)
+    }
+
+    /// Return the `notAfter` validity timestamp as a string.
     pub fn not_after(&self) -> String {
         self.borrow_cert().validity.not_after.to_string()
     }
@@ -220,5 +251,54 @@ impl Hash for CertKey {
 impl<'a> From<&'a WrappedX509> for CertificateDer<'static> {
     fn from(value: &'a WrappedX509) -> Self {
         CertificateDer::from(value.borrow_raw_cert().as_slice().to_owned())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use x509_parser::pem::Pem;
+
+    use super::WrappedX509;
+
+    #[test]
+    fn parse_valid_der() {
+        let der = test_der_bytes();
+        let wrapped = WrappedX509::parse(der.clone()).expect("valid DER must parse");
+        assert_eq!(
+            wrapped.borrow_raw_cert(),
+            &der,
+            "raw_cert must match the input"
+        );
+    }
+
+    #[test]
+    fn parse_invalid_der_returns_error() {
+        let garbage = vec![0xFF, 0x00, 0xDE, 0xAD];
+        let result = WrappedX509::parse(garbage);
+        assert!(result.is_err(), "garbage bytes must produce an error");
+    }
+
+    #[test]
+    fn parse_empty_der_returns_error() {
+        let result = WrappedX509::parse(Vec::new());
+        assert!(result.is_err(), "empty input must produce an error");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test Utilities
+    // ---------------------------------------------------------------------------
+
+    /// Extract DER bytes from the bundled test PEM certificate.
+    fn test_der_bytes() -> Vec<u8> {
+        let pem_bytes = include_bytes!("../../../tests/keys/server.crt");
+        Pem::iter_from_buffer(pem_bytes)
+            .next()
+            .expect("PEM must contain at least one block")
+            .expect("PEM must parse")
+            .contents
     }
 }

--- a/pingora-core/src/utils/tls/s2n.rs
+++ b/pingora-core/src/utils/tls/s2n.rs
@@ -20,6 +20,8 @@ use x509_parser::{
     prelude::{FromDer, X509Certificate},
 };
 
+/// Extract the organization and serial from a raw [`X509Certificate`]
+/// reference.
 fn get_organization_serial_x509(
     x509cert: &X509Certificate<'_>,
 ) -> Result<(Option<String>, String)> {
@@ -134,18 +136,23 @@ impl CertKey {
         get_serial(self.leaf()).unwrap()
     }
 
+    /// Return the raw PEM bytes.
     pub fn raw_pem(&self) -> &[u8] {
         &self.pem.raw_pem
     }
 }
 
+/// Parsed PEM bundle containing one or more X.509 certificates.
 #[derive(Debug)]
 pub struct X509Pem {
+    /// The original PEM bytes.
     pub raw_pem: Vec<u8>,
+    /// The parsed certificates.
     pub certs: Vec<WrappedX509>,
 }
 
 impl X509Pem {
+    /// Parse a PEM-encoded certificate bundle.
     pub fn new(raw_pem: Vec<u8>) -> Self {
         let certs = Pem::iter_from_buffer(&raw_pem)
             .map(|part| {
@@ -156,11 +163,32 @@ impl X509Pem {
         X509Pem { raw_pem, certs }
     }
 
+    /// Iterate over the parsed certificates.
     pub fn iter(&self) -> std::slice::Iter<'_, WrappedX509> {
         self.certs.iter()
     }
 }
 
+/// Fallible variant of certificate parsing for use with
+/// [`WrappedX509::try_new`].
+fn try_parse_x509<C>(raw_cert: &C) -> Result<X509Certificate<'_>>
+where
+    C: AsRef<[u8]>,
+{
+    X509Certificate::from_der(raw_cert.as_ref())
+        .map(|(_, cert)| cert)
+        .map_err(|e| {
+            pingora_error::Error::explain(
+                pingora_error::ErrorType::InternalError,
+                format!("failed to parse DER certificate: {e}"),
+            )
+        })
+}
+
+/// Infallible certificate parse; panics on invalid DER.
+///
+/// Kept for internal callers ([`X509Pem::new`]) that already
+/// guarantee valid input.
 fn parse_x509<C>(raw_cert: &C) -> X509Certificate<'_>
 where
     C: AsRef<[u8]>,
@@ -181,6 +209,15 @@ pub struct WrappedX509 {
 }
 
 impl WrappedX509 {
+    /// Parse DER-encoded certificate bytes into a [`WrappedX509`].
+    ///
+    /// Returns an error if the bytes are not a valid DER-encoded
+    /// X.509 certificate.
+    pub fn parse(raw_cert: Vec<u8>) -> Result<Self> {
+        Self::try_new(raw_cert, try_parse_x509)
+    }
+
+    /// Return the `notAfter` validity timestamp as a string.
     pub fn not_after(&self) -> String {
         self.borrow_cert().validity.not_after.to_string()
     }
@@ -223,5 +260,54 @@ impl Hash for X509Pem {
 impl Hash for CertKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.pem.hash(state)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use x509_parser::pem::Pem;
+
+    use super::WrappedX509;
+
+    #[test]
+    fn parse_valid_der() {
+        let der = test_der_bytes();
+        let wrapped = WrappedX509::parse(der.clone()).expect("valid DER must parse");
+        assert_eq!(
+            wrapped.borrow_raw_cert(),
+            &der,
+            "raw_cert must match the input"
+        );
+    }
+
+    #[test]
+    fn parse_invalid_der_returns_error() {
+        let garbage = vec![0xFF, 0x00, 0xDE, 0xAD];
+        let result = WrappedX509::parse(garbage);
+        assert!(result.is_err(), "garbage bytes must produce an error");
+    }
+
+    #[test]
+    fn parse_empty_der_returns_error() {
+        let result = WrappedX509::parse(Vec::new());
+        assert!(result.is_err(), "empty input must produce an error");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test Utilities
+    // ---------------------------------------------------------------------------
+
+    /// Extract DER bytes from the bundled test PEM certificate.
+    fn test_der_bytes() -> Vec<u8> {
+        let pem_bytes = include_bytes!("../../../tests/keys/server.crt");
+        Pem::iter_from_buffer(pem_bytes)
+            .next()
+            .expect("PEM must contain at least one block")
+            .expect("PEM must parse")
+            .contents
     }
 }


### PR DESCRIPTION
This enables a deeper level of control from implementations utilizing Pingora over certificates.

This is being paired with #726 in our fork right now. 