### PR TITLE
bump reqwest to 0.12

### DIFF
--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -86,7 +86,7 @@ windows-sys = { version = "0.59.0", features = ["Win32_Networking_WinSock"] }
 h2 = { workspace = true, features = ["unstable"] }
 tokio-stream = { version = "0.1", features = ["full"] }
 env_logger = "0.11"
-reqwest = { version = "0.11", features = [
+reqwest = { version = "0.12", features = [
     "rustls-tls",
 ], default-features = false }
 hyper = "0.14"

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -36,14 +36,14 @@ regex = "1"
 rand = "0.8"
 
 [dev-dependencies]
-reqwest = { version = "0.11", features = [
+reqwest = { version = "0.12", features = [
     "gzip",
     "rustls-tls",
 ], default-features = false }
 httparse = { workspace = true }
 tokio-test = "0.4"
 env_logger = "0.11"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["http2"] }
 tokio-tungstenite = "0.20.1"
 pingora-limits = { version = "0.8.0", path = "../pingora-limits" }
 pingora-load-balancing = { version = "0.8.0", path = "../pingora-load-balancing", default-features=false }

--- a/pingora-proxy/tests/test_basic.rs
+++ b/pingora-proxy/tests/test_basic.rs
@@ -172,8 +172,8 @@ async fn test_h2c_to_h2c() {
     req.headers_mut()
         .insert("x-h2", HeaderValue::from_bytes(b"true").unwrap());
     let res = client.request(req).await.unwrap();
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(res.version(), reqwest::Version::HTTP_2);
+    assert_eq!(res.status(), hyper::StatusCode::OK);
+    assert_eq!(res.version(), hyper::Version::HTTP_2);
 
     let body = res.into_body().data().await.unwrap().unwrap();
     assert_eq!(body.as_ref(), b"Hello World!\n");
@@ -194,8 +194,8 @@ async fn test_h1_on_h2c_port() {
     req.headers_mut()
         .insert("x-h2", HeaderValue::from_bytes(b"true").unwrap());
     let res = client.request(req).await.unwrap();
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(res.version(), reqwest::Version::HTTP_11);
+    assert_eq!(res.status(), hyper::StatusCode::OK);
+    assert_eq!(res.version(), hyper::Version::HTTP_11);
 
     let body = res.into_body().data().await.unwrap().unwrap();
     assert_eq!(body.as_ref(), b"Hello World!\n");
@@ -307,11 +307,11 @@ async fn test_simple_proxy_uds() {
 
     let res = client.get(url).await.unwrap();
 
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.status(), hyper::StatusCode::OK);
     let (resp, body) = res.into_parts();
 
     let headers = &resp.headers;
-    assert_eq!(headers[header::CONTENT_LENGTH], "13");
+    assert_eq!(headers[hyper::header::CONTENT_LENGTH], "13");
     assert_eq!(headers["x-server-addr"], "/tmp/pingora_proxy.sock");
     assert_eq!(headers["x-client-addr"], "unset"); // unnamed UDS
 

--- a/pingora-proxy/tests/test_upstream.rs
+++ b/pingora-proxy/tests/test_upstream.rs
@@ -18,8 +18,9 @@ use utils::server_utils::init;
 use utils::websocket::{WS_ECHO, WS_ECHO_RAW};
 
 use futures::{SinkExt, StreamExt};
+use hyper::header::HeaderValue;
 use pingora_http::ResponseHeader;
-use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::header::{HeaderName, HeaderValue as ReqwestHeaderValue};
 use reqwest::{StatusCode, Version};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -374,7 +375,7 @@ async fn test_download_timeout() {
         .body(hyper::Body::empty())
         .unwrap();
     let mut res = client.request(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), hyper::StatusCode::OK);
 
     let mut err = false;
     sleep(Duration::from_secs(2)).await;
@@ -401,7 +402,7 @@ async fn test_download_timeout_min_rate() {
         .body(hyper::Body::empty())
         .unwrap();
     let mut res = client.request(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), hyper::StatusCode::OK);
 
     let mut err = false;
     sleep(Duration::from_secs(2)).await;
@@ -2924,7 +2925,7 @@ mod test_cache {
             .map(|(name, value)| {
                 (
                     HeaderName::from_str(name).unwrap(),
-                    HeaderValue::from_str(value).unwrap(),
+                    ReqwestHeaderValue::from_str(value).unwrap(),
                 )
             })
             .collect();

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -37,7 +37,7 @@ document-features = { version = "0.2.10", optional = true }
 clap = { version = "4.5", features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 env_logger = "0.11"
-reqwest = { version = "0.11", features = ["rustls"], default-features = false }
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 hyper = "0.14"
 async-trait = { workspace = true }
 http = { workspace = true }


### PR DESCRIPTION
Solves #859 and #860. Note that this PR changed `[dev-dependencies]`, but not `[dependencies]` . 

New CI runs on `main` branch for `pingora (1.91.1)` are broken due to the two issues above. The error and the dependency tree can be found below.

```
Crate:     rustls-webpki
Version:   0.101.7
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
error: 2 vulnerabilities found!
warning: 5 allowed warnings found
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
Dependency tree:
rustls-webpki 0.101.7
└── rustls 0.21.12
    ├── tokio-rustls 0.24.1
    │   ├── reqwest 0.11.27
    │   │   ├── pingora-proxy 0.8.0
    │   │   │   └── pingora 0.8.0
    │   │   ├── pingora-core 0.8.0
    │   │   │   ├── pingora-proxy 0.8.0
    │   │   │   ├── pingora-load-balancing 0.8.0
    │   │   │   │   ├── pingora-proxy 0.8.0
    │   │   │   │   └── pingora 0.8.0
    │   │   │   ├── pingora-cache 0.8.0
    │   │   │   │   ├── pingora-proxy 0.8.0
    │   │   │   │   └── pingora 0.8.0
    │   │   │   └── pingora 0.8.0
    │   │   └── pingora 0.8.0
    │   └── hyper-rustls 0.24.2
    │       └── reqwest 0.11.27
    ├── reqwest 0.11.27
    └── hyper-rustls 0.24.2
```

From https://github.com/cloudflare/pingora/actions/runs/24522708067/job/71684542097?pr=862
