### PR TITLE
Add H1 same-connection redirect follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+**🚀 Features**
+
+* Add `Session::h1_set_same_connection_followup` for following an HTTP/1.1 redirect on a single pooled upstream connection; disables cache for the skipped intermediate hop when caching is enabled.
+
+**📚 Documentation**
+
+* `ProxyHttp::response_filter`: point to the new follow-up API for same-connection redirect handling.
+
 ## [0.8.0](https://github.com/cloudflare/pingora/compare/0.7.0...0.8.0) - 2026-03-02
 
 

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -366,6 +366,10 @@ impl Peer for BasicPeer {
     fn reuse_hash(&self) -> u64 {
         let mut hasher = AHasher::default();
         self._address.hash(&mut hasher);
+        // If TLS is used, the SNI must be part of the reuse key to avoid
+        // cross-host connection reuse (different SNI/hostname on same IP:port).
+        // When SNI is empty (non-TLS), this keeps the historical behavior.
+        self.sni.hash(&mut hasher);
         hasher.finish()
     }
 

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -76,6 +76,13 @@ use pingora_core::server::ShutdownWatch;
 use pingora_core::upstreams::peer::{HttpPeer, Peer};
 use pingora_error::{Error, ErrorSource, ErrorType::*, OrErr, Result};
 
+fn is_benign_upstream_retry_log(e: &Error) -> bool {
+    matches!(&e.etype, HTTPStatus(code) if (300..400).contains(code))
+        && e.context
+            .as_ref()
+            .is_some_and(|c| c.as_str().starts_with("redirect_follow_hop:"))
+}
+
 const TASK_BUFFER_SIZE: usize = 4;
 
 mod proxy_cache;
@@ -977,13 +984,23 @@ where
                         break;
                     }
                     // only log error that will be retried here, the final error will be logged below
-                    warn!(
-                        "Fail to proxy: {}, tries: {}, retry: {}, {}",
-                        proxy_error.as_ref().unwrap(),
-                        retries,
-                        retry,
-                        self.inner.request_summary(&session, &ctx)
-                    );
+                    if is_benign_upstream_retry_log(proxy_error.as_ref().unwrap()) {
+                        debug!(
+                            "Redirect follow: {}, tries: {}, retry: {}, {}",
+                            proxy_error.as_ref().unwrap(),
+                            retries,
+                            retry,
+                            self.inner.request_summary(&session, &ctx)
+                        );
+                    } else {
+                        warn!(
+                            "Fail to proxy: {}, tries: {}, retry: {}, {}",
+                            proxy_error.as_ref().unwrap(),
+                            retries,
+                            retry,
+                            self.inner.request_summary(&session, &ctx)
+                        );
+                    }
                 }
                 None => {
                     proxy_error = None;

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -480,6 +480,8 @@ pub struct Session {
     upstream_body_bytes_received: usize,
     /// Upstream write pending time. Set by proxy layer (HTTP/1.x only).
     upstream_write_pending_time: Duration,
+    h1_skip_downstream_response: bool,
+    h1_same_connection_followup: Option<RequestHeader>,
     /// Flag that is set when the shutdown process has begun.
     shutdown_flag: Arc<AtomicBool>,
 }
@@ -502,6 +504,8 @@ impl Session {
             downstream_modules_ctx: downstream_modules.build_ctx(),
             upstream_body_bytes_received: 0,
             upstream_write_pending_time: Duration::ZERO,
+            h1_skip_downstream_response: false,
+            h1_same_connection_followup: None,
             shutdown_flag,
         }
     }
@@ -740,6 +744,23 @@ impl Session {
     /// Set the upstream write pending time. Intended for internal use by proxy layer.
     pub(crate) fn set_upstream_write_pending_time(&mut self, d: Duration) {
         self.upstream_write_pending_time = d;
+    }
+
+    /// Queue a follow-up request on the same HTTP/1.1 upstream connection after the current
+    /// response body is consumed, without sending that response downstream. Use from
+    /// `response_filter` (e.g. after a 3xx with a same-origin `Location`). Disables caching for
+    /// the skipped hop when cache is enabled.
+    pub fn h1_set_same_connection_followup(&mut self, request: RequestHeader) {
+        if self.cache.enabled() {
+            self.cache
+                .disable(NoCacheReason::Custom("H1SameConnectionRedirect"));
+        }
+        self.h1_skip_downstream_response = true;
+        self.h1_same_connection_followup = Some(request);
+    }
+
+    pub(crate) fn h1_skip_downstream_for_upstream_response(&self) -> bool {
+        self.h1_skip_downstream_response
     }
 
     /// Is the proxy process in the process of shutting down (e.g. due to graceful upgrade)?
@@ -1481,5 +1502,23 @@ where
 
         proxy.handle_init_modules();
         Service::new(name, proxy)
+    }
+}
+
+#[cfg(test)]
+mod h1_same_connection_tests {
+    use super::{RequestHeader, Session};
+    use http::Method;
+    use pingora_core::protocols::Stream;
+
+    #[tokio::test]
+    async fn followup_skips_intermediate_response_downstream() {
+        let input = b"GET /a HTTP/1.1\r\nHost: t\r\n\r\n";
+        let io = tokio_test::io::Builder::new().read(&input[..]).build();
+        let mut session = Session::new_h1(Box::new(io) as Stream);
+        assert!(session.read_request().await.unwrap());
+        let next = RequestHeader::build(Method::GET, b"/b", None).unwrap();
+        session.h1_set_same_connection_followup(next);
+        assert!(session.h1_skip_downstream_for_upstream_response());
     }
 }

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -167,14 +167,28 @@ where
             return (false, false, Some(e));
         }
 
-        let (server_session_reuse, client_session_reuse, error) =
-            self.proxy_1to1(session, client_session, peer, ctx).await;
+        let mut server_session_reuse;
+        let mut client_session_reuse;
+        let mut error: Option<Box<Error>>;
 
-        // Record upstream response body bytes received (payload only) for logging consumers.
+        loop {
+            if let Some(next_req) = session.h1_same_connection_followup.take() {
+                *session.req_header_mut() = next_req;
+                session.h1_skip_downstream_response = false;
+            }
+
+            (server_session_reuse, client_session_reuse, error) =
+                self.proxy_1to1(session, client_session, peer, ctx).await;
+
+            if error.is_none() && session.h1_same_connection_followup.is_some() {
+                continue;
+            }
+            break;
+        }
+
         let upstream_bytes_total = client_session.body_bytes_received();
         session.set_upstream_body_bytes_received(upstream_bytes_total);
 
-        // Record upstream write pending time for this session only (delta from baseline).
         let current_write_pending = client_session.stream().get_write_pending_time();
         let upstream_write_pending = current_write_pending.saturating_sub(initial_write_pending);
         session.set_upstream_write_pending_time(upstream_write_pending);
@@ -324,7 +338,9 @@ where
             }
             // check error and abort
             // otherwise the error is surfaced via write_response_tasks()
-            if !serve_from_cache.should_send_to_downstream() {
+            if !serve_from_cache.should_send_to_downstream()
+                || session.h1_skip_downstream_for_upstream_response()
+            {
                 if let HttpTask::Failed(e) = task {
                     return Err(e);
                 }
@@ -332,7 +348,9 @@ where
             filtered_tasks.push(task);
         }
 
-        if !serve_from_cache.should_send_to_downstream() {
+        if !serve_from_cache.should_send_to_downstream()
+            || session.h1_skip_downstream_for_upstream_response()
+        {
             // TODO: need to derive response_done from filtered_tasks in case downstream failed already
             return Ok(None);
         }

--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -349,6 +349,9 @@ pub trait ProxyHttp {
     ///
     /// The modification is after caching. This filter is called for all responses including
     /// responses served from cache.
+    ///
+    /// To follow a redirect on the same HTTP/1.1 upstream connection (without using the outer
+    /// proxy retry path), use [`crate::Session::h1_set_same_connection_followup`].
     async fn response_filter(
         &self,
         _session: &mut Session,


### PR DESCRIPTION
Summary

Adds Session::h1_set_same_connection_followup so user code can follow an HTTP/1.1 upstream redirect (e.g. 3xx) on the same pooled upstream connection: the intermediate response body is consumed without writing it to the client, then a follow-up request is issued on that connection via an internal loop in proxy_to_h1_upstream. This avoids the pattern of returning Err from response_filter and relying on the outer process_request retry loop, which drops upstream keep-alive (client_reuse == false and no release_http_session on that path).

Related issue: https://github.com/cloudflare/pingora/issues/866

Motivation

Following redirects by erroring out of response_filter causes proxy_1to1 to fail try_join! and return client_reuse = false, so each retry opens a new upstream connection. At scale this hurts latency and connection reuse. RFC-aligned behavior for H/1 is to drain the redirect response on the same TCP connection when the next hop is the same origin, then send the next request on that connection.

What changed

Session: optional follow-up RequestHeader, flag to skip writing the current upstream response downstream, and h1_set_same_connection_followup (disables cache for the skipped hop when caching is enabled).
proxy_to_h1_upstream: loops while a follow-up is scheduled after a successful proxy_1to1 leg.
process_upstream_tasks: when skipping downstream for the current response, does not forward response tasks to the client while the upstream side still drains the body through the filter chain.
Docs: ProxyHttp::response_filter points to the new API.
CHANGELOG: Unreleased entry.
Unit test for the follow-up / skip behavior.
Usage (conceptual)

From response_filter, on an intermediate response you choose to follow on the same connection, build the next RequestHeader and call session.h1_set_same_connection_followup(request) and return Ok(()). Do not use this for untrusted cross-origin redirects without validating Location in application code.

Testing

cargo test -p pingora-proxy --lib
