### PR TITLE
flush pingora stream immediately

### DIFF
--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -1159,6 +1159,12 @@ impl HttpSession {
             }
             HttpTask::UpgradedBody(data, end_stream) => {
                 self.write_non_empty_body(data, true).await?;
+                if !end_stream {
+                    self.underlying_stream
+                        .flush()
+                        .await
+                        .or_err(WriteError, "flushing upgraded body")?;
+                }
                 end_stream
             }
             HttpTask::Trailer(_) => true, // h1 trailer is not supported yet
@@ -1231,6 +1237,11 @@ impl HttpSession {
         if end_stream {
             // no-op if body wasn't initialized or is finished already
             self.finish_body().await.map_err(|e| e.into_down())?;
+        } else if self.upgraded {
+            self.underlying_stream
+                .flush()
+                .await
+                .or_err(WriteError, "flushing upgraded body")?;
         }
         Ok(end_stream || self.body_writer.finished())
     }


### PR DESCRIPTION
currently when sending wss requests through pingora, the rtt of a connection lifecycle + sending/receiving a request is ~1300ms compared to baseline ~300ms wss requests through caddy. The additional 1000ms comes from the websocket close handshake (which sends a close frame and waits for server's close frame reply). this exclusively happens in pingora. This takes 1s because the close frame gets buffered until tcp connection timeout. Caddy doesn't have this issue because it flushes immediately for proxied websocket data.

<img width="982" height="283" alt="image" src="https://github.com/user-attachments/assets/721a1ab7-51d4-407f-8596-ed12fedac4a7" />

this patch fixes the issue by flushing wss requests immediately: 
<img width="1023" height="394" alt="image" src="https://github.com/user-attachments/assets/17da11a7-eb7a-46b6-bb5a-1a909929fc63" />
