### PR TITLE
Add flags to enable X509_V_FLAG_PARTIAL_CHAIN in upstream connector

### DIFF
--- a/pingora-core/src/connectors/tls/boringssl_openssl/mod.rs
+++ b/pingora-core/src/connectors/tls/boringssl_openssl/mod.rs
@@ -30,6 +30,7 @@ use crate::tls::ext::{
 use crate::tls::ssl::SslCurve;
 use crate::tls::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode, SslVersion};
 use crate::tls::x509::store::X509StoreBuilder;
+use crate::tls::x509::verify::X509VerifyFlags;
 use crate::upstreams::peer::{Peer, ALPN};
 
 pub type TlsConnector = SslConnector;
@@ -210,6 +211,12 @@ where
         consistent with nginx's behavior */
         ssl_conf.set_verify(SslVerifyMode::NONE);
     } else if peer.verify_cert() {
+        if peer.verify_cert_partial_chain() {
+            ssl_conf
+                .param_mut()
+                .set_flags(X509VerifyFlags::PARTIAL_CHAIN)
+                .or_err(InternalError, "failed to set verify flags")?;
+        }
         if peer.verify_hostname() {
             let verify_param = ssl_conf.param_mut();
             add_host(verify_param, peer.sni()).or_err(InternalError, "failed to add host")?;

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -127,6 +127,14 @@ pub trait Peer: Display + Clone {
             None => false,
         }
     }
+    /// Whether certificate verification should accept chains anchored at an intermediate CA in
+    /// the configured trust store.
+    fn verify_cert_partial_chain(&self) -> bool {
+        match self.get_peer_options() {
+            Some(opt) => opt.verify_cert_partial_chain,
+            None => false,
+        }
+    }
     /// Whether the system trust store should be loaded and used when verifying certificates
     #[cfg(feature = "s2n")]
     fn use_system_certs(&self) -> bool {
@@ -415,6 +423,8 @@ pub struct PeerOptions {
     pub write_timeout: Option<Duration>,
     pub verify_cert: bool,
     pub verify_hostname: bool,
+    /// Accept chains that terminate at an intermediate CA present in the trust store.
+    pub verify_cert_partial_chain: bool,
     #[cfg(feature = "s2n")]
     pub use_system_certs: bool,
     /* accept the cert if it's CN matches the SNI or this name */
@@ -484,6 +494,7 @@ impl PeerOptions {
             write_timeout: None,
             verify_cert: true,
             verify_hostname: true,
+            verify_cert_partial_chain: false,
             #[cfg(feature = "s2n")]
             use_system_certs: true,
             alternative_cn: None,
@@ -538,6 +549,9 @@ impl Display for PeerOptions {
         }
         if self.verify_hostname {
             write!(f, "verify_hostname: true,")?;
+        }
+        if self.verify_cert_partial_chain {
+            write!(f, "verify_cert_partial_chain: true,")?;
         }
         #[cfg(feature = "s2n")]
         if self.use_system_certs {
@@ -687,6 +701,7 @@ impl Hash for HttpPeer {
         // origin server cert verification
         self.verify_cert().hash(state);
         self.verify_hostname().hash(state);
+        self.verify_cert_partial_chain().hash(state);
         self.alternative_cn().hash(state);
         #[cfg(feature = "s2n")]
         self.get_psk().hash(state);


### PR DESCRIPTION
Trust-chain verification is sometimes relieved for the communication within trusted environment (e.g. inter DC, Office VPN)

Pingora is generic proxy framework. Hence it can be used not only as edge proxy but also service proxy. So having a knob to switch them for upstream connection is also helpful as generic proxy framework.

`X509_V_FLAG_PARTIAL_CHAIN` is often used to achieve this requirement, and this flag is enabled by default in service proxy (e.g. [Envoy](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto)).
