### PR TITLE
feat(tls): add SNI to SslDigest for HTTP filter access

### DIFF
--- a/pingora-core/src/protocols/tls/boringssl_openssl/stream.rs
+++ b/pingora-core/src/protocols/tls/boringssl_openssl/stream.rs
@@ -209,7 +209,11 @@ impl SslDigest {
             None => (Vec::new(), None, None),
         };
 
-        SslDigest::new(cipher, ssl.version_str(), org, sn, cert_digest)
+        let sni = ssl
+            .servername(ssl::NameType::HOST_NAME)
+            .map(ToOwned::to_owned);
+
+        SslDigest::new(cipher, ssl.version_str(), org, sn, cert_digest, sni)
     }
 }
 

--- a/pingora-core/src/protocols/tls/digest.rs
+++ b/pingora-core/src/protocols/tls/digest.rs
@@ -31,6 +31,8 @@ pub struct SslDigest {
     pub serial_number: Option<String>,
     /// The digest of the peer's certificate
     pub cert_digest: Vec<u8>,
+    /// The SNI used during the TLS handshake
+    pub sni: Option<String>,
     /// The user-defined TLS data
     pub extension: SslDigestExtension,
 }
@@ -43,6 +45,7 @@ impl SslDigest {
         organization: Option<String>,
         serial_number: Option<String>,
         cert_digest: Vec<u8>,
+        sni: Option<String>,
     ) -> Self
     where
         S: Into<Cow<'static, str>>,
@@ -53,6 +56,7 @@ impl SslDigest {
             organization,
             serial_number,
             cert_digest,
+            sni,
             extension: SslDigestExtension::default(),
         }
     }

--- a/pingora-core/src/protocols/tls/rustls/stream.rs
+++ b/pingora-core/src/protocols/tls/rustls/stream.rs
@@ -390,7 +390,10 @@ impl SslDigest {
             .map(|(organization, serial)| (organization, Some(serial)))
             .unwrap_or_default();
 
-        SslDigest::new(cipher, version, organization, serial_number, cert_digest)
+        // SNI extraction not yet implemented for rustls
+        let sni = None;
+
+        SslDigest::new(cipher, version, organization, serial_number, cert_digest, sni)
     }
 }
 

--- a/pingora-core/src/protocols/tls/s2n/stream.rs
+++ b/pingora-core/src/protocols/tls/s2n/stream.rs
@@ -307,12 +307,16 @@ impl SslDigest {
             }
         }
 
+        // SNI extraction not yet implemented for s2n
+        let sni = None;
+
         SslDigest::new(
             cipher,
             version,
             organization,
             serial_number,
             cert_digest.unwrap_or_default(),
+            sni,
         )
     }
 }


### PR DESCRIPTION
This PR adds the SNI (Server Name Indication) to the `SslDigest` struct, addressing the request in #547 to make SNI accessible in the HTTP filter context.

The implementation follows the approach suggested in the issue comments by @pszabop. When using boringssl or openssl, the SNI is extracted from the SSL connection during handshake and stored in `SslDigest`. This allows users to access it in their `request_filter` callback:

```rust
async fn request_filter(&self, session: &mut Session, ctx: &mut Self::CTX) -> Result<bool> {
    if let Some(digest) = session.digest() {
        if let Some(ssl_digest) = &digest.ssl_digest {
            if let Some(sni) = &ssl_digest.sni {
                // Compare with HTTP Host header, route based on SNI, etc.
            }
        }
    }
    Ok(false)
}
```

The rustls and s2n backends currently pass `None` for SNI. Extending those backends can be done in follow-up work.

Fixes #547
