### PR TITLE
Return rustls listener FIPS failures as errors

### DIFF
--- a/pingora-core/src/listeners/mod.rs
+++ b/pingora-core/src/listeners/mod.rs
@@ -151,7 +151,11 @@ impl TransportStackBuilder {
 
         Ok(TransportStack {
             l4,
-            tls: self.tls.take().map(|tls| Arc::new(tls.build())),
+            tls: self
+                .tls
+                .take()
+                .map(|tls| tls.try_build().map(Arc::new))
+                .transpose()?,
             l4_buffer: self.l4_buffer,
         })
     }

--- a/pingora-core/src/listeners/tls/boringssl_openssl/mod.rs
+++ b/pingora-core/src/listeners/tls/boringssl_openssl/mod.rs
@@ -135,6 +135,10 @@ impl TlsSettings {
             callbacks: self.callbacks,
         }
     }
+
+    pub(crate) fn try_build(self) -> Result<Acceptor> {
+        Ok(self.build())
+    }
 }
 
 impl Acceptor {

--- a/pingora-core/src/listeners/tls/rustls/mod.rs
+++ b/pingora-core/src/listeners/tls/rustls/mod.rs
@@ -23,8 +23,8 @@ use pingora_rustls::load_certs_and_key_files;
 use pingora_rustls::ClientCertVerifier;
 use pingora_rustls::ServerConfig;
 use pingora_rustls::{
-    version, CryptoProvider, ResolvesServerCert, SupportedCipherSuite, SupportedKxGroup,
-    SupportedProtocolVersion, TlsAcceptor as RusTlsAcceptor,
+    version, CertificateHashProvider, CryptoProvider, ResolvesServerCert, SupportedCipherSuite,
+    SupportedKxGroup, SupportedProtocolVersion, TlsAcceptor as RusTlsAcceptor,
 };
 
 use crate::protocols::{ALPN, IO};
@@ -46,6 +46,7 @@ pub struct TlsSettings {
 
 pub struct Acceptor {
     pub acceptor: RusTlsAcceptor,
+    pub(crate) cert_digest_hash: Option<&'static CertificateHashProvider>,
     callbacks: Option<TlsAcceptCallbacks>,
 }
 
@@ -107,6 +108,8 @@ impl TlsSettings {
         if let Some(alpn_protocols) = self.alpn_protocols {
             config.alpn_protocols = alpn_protocols;
         }
+        let cert_digest_hash =
+            pingora_rustls::sha256_hash_provider(config.crypto_provider().as_ref());
         if self.require_fips && !config.fips() {
             return Error::e_explain(
                 InternalError,
@@ -116,9 +119,16 @@ impl TlsSettings {
                 ),
             );
         }
+        if self.require_fips && cert_digest_hash.is_none() {
+            return Error::e_explain(
+                InternalError,
+                "Rustls listener configuration does not provide a SHA-256 hash provider for certificate digests.",
+            );
+        }
 
         Ok(Acceptor {
             acceptor: RusTlsAcceptor::from(Arc::new(config)),
+            cert_digest_hash,
             callbacks: None,
         })
     }

--- a/pingora-core/src/listeners/tls/rustls/mod.rs
+++ b/pingora-core/src/listeners/tls/rustls/mod.rs
@@ -22,16 +22,26 @@ use pingora_error::{Error, OrErr, Result};
 use pingora_rustls::load_certs_and_key_files;
 use pingora_rustls::ClientCertVerifier;
 use pingora_rustls::ServerConfig;
-use pingora_rustls::{version, TlsAcceptor as RusTlsAcceptor};
+use pingora_rustls::{
+    version, CryptoProvider, ResolvesServerCert, SupportedCipherSuite, SupportedKxGroup,
+    SupportedProtocolVersion, TlsAcceptor as RusTlsAcceptor,
+};
 
 use crate::protocols::{ALPN, IO};
+
+static TLS12_AND_13: [&SupportedProtocolVersion; 2] = [&version::TLS12, &version::TLS13];
+static TLS13_ONLY: [&SupportedProtocolVersion; 1] = [&version::TLS13];
 
 /// The TLS settings of a listening endpoint
 pub struct TlsSettings {
     alpn_protocols: Option<Vec<Vec<u8>>>,
+    protocol_versions: &'static [&'static SupportedProtocolVersion],
+    crypto_provider: Option<CryptoProvider>,
     cert_path: String,
     key_path: String,
     client_cert_verifier: Option<Arc<dyn ClientCertVerifier>>,
+    cert_resolver: Option<Arc<dyn ResolvesServerCert>>,
+    require_fips: bool,
 }
 
 pub struct Acceptor {
@@ -46,41 +56,71 @@ impl TlsSettings {
     /// _NOTE_ This function will panic if there is an error in loading
     /// certificate files or constructing the builder
     ///
-    /// Todo: Return a result instead of panicking XD
+    /// Use [`Self::try_build`] to receive these failures as a [`Result`].
     pub fn build(self) -> Acceptor {
+        self.try_build().unwrap()
+    }
+
+    /// Create a Rustls acceptor and return configuration failures as errors.
+    pub fn try_build(self) -> Result<Acceptor> {
+        let has_cert_resolver = self.cert_resolver.is_some();
         // rustls 0.23+ requires an explicit CryptoProvider.
-        pingora_rustls::install_default_crypto_provider();
+        let builder = if let Some(crypto_provider) = self.crypto_provider {
+            ServerConfig::builder_with_provider(Arc::new(crypto_provider))
+                .with_protocol_versions(self.protocol_versions)
+        } else {
+            pingora_rustls::install_default_crypto_provider();
+            Ok(ServerConfig::builder_with_protocol_versions(
+                self.protocol_versions,
+            ))
+        }
+        .explain_err(InternalError, |e| {
+            format!("Failed to create server listener config builder: {e}")
+        })?;
 
-        let Ok(Some((certs, key))) = load_certs_and_key_files(&self.cert_path, &self.key_path)
-        else {
-            panic!(
-                "Failed to load provided certificates \"{}\" or key \"{}\".",
-                self.cert_path, self.key_path
-            )
-        };
-
-        let builder =
-            ServerConfig::builder_with_protocol_versions(&[&version::TLS12, &version::TLS13]);
         let builder = if let Some(verifier) = self.client_cert_verifier {
             builder.with_client_cert_verifier(verifier)
         } else {
             builder.with_no_client_auth()
         };
-        let mut config = builder
-            .with_single_cert(certs, key)
-            .explain_err(InternalError, |e| {
-                format!("Failed to create server listener config: {e}")
-            })
-            .unwrap();
+        let mut config = if let Some(cert_resolver) = self.cert_resolver {
+            builder.with_cert_resolver(cert_resolver)
+        } else {
+            let (certs, key) = load_certs_and_key_files(&self.cert_path, &self.key_path)?
+                .ok_or_else(|| {
+                    Error::explain(
+                        InternalError,
+                        format!(
+                            "Failed to load provided certificates \"{}\" or key \"{}\".",
+                            self.cert_path, self.key_path
+                        ),
+                    )
+                })?;
+
+            builder
+                .with_single_cert(certs, key)
+                .explain_err(InternalError, |e| {
+                    format!("Failed to create server listener config: {e}")
+                })?
+        };
 
         if let Some(alpn_protocols) = self.alpn_protocols {
             config.alpn_protocols = alpn_protocols;
         }
+        if self.require_fips && !config.fips() {
+            return Error::e_explain(
+                InternalError,
+                format!(
+                    "Rustls listener configuration does not report FIPS mode; cert_path=\"{}\" key_path=\"{}\" cert_resolver={}",
+                    self.cert_path, self.key_path, has_cert_resolver
+                ),
+            );
+        }
 
-        Acceptor {
+        Ok(Acceptor {
             acceptor: RusTlsAcceptor::from(Arc::new(config)),
             callbacks: None,
-        }
+        })
     }
 
     /// Enable HTTP/2 support for this endpoint, which is default off.
@@ -93,9 +133,48 @@ impl TlsSettings {
         self.alpn_protocols = Some(alpn.to_wire_protocols());
     }
 
+    /// Configure ALPN protocols directly.
+    pub fn set_alpn_protocols(&mut self, protocols: Vec<Vec<u8>>) {
+        self.alpn_protocols = Some(protocols);
+    }
+
+    /// Require at least TLS 1.2 for this endpoint.
+    pub fn set_min_protocol_tls12(&mut self) {
+        self.protocol_versions = &TLS12_AND_13;
+    }
+
+    /// Require at least TLS 1.3 for this endpoint.
+    pub fn set_min_protocol_tls13(&mut self) {
+        self.protocol_versions = &TLS13_ONLY;
+    }
+
+    /// Set the rustls crypto provider for this endpoint.
+    pub fn set_crypto_provider(&mut self, crypto_provider: CryptoProvider) {
+        self.crypto_provider = Some(crypto_provider);
+    }
+
+    /// Set the supported cipher suites for this endpoint.
+    pub fn set_cipher_suites(&mut self, cipher_suites: Vec<SupportedCipherSuite>) {
+        self.crypto_provider
+            .get_or_insert_with(pingora_rustls::ring_default_crypto_provider)
+            .cipher_suites = cipher_suites;
+    }
+
+    /// Set the supported key exchange groups for this endpoint.
+    pub fn set_kx_groups(&mut self, kx_groups: Vec<&'static dyn SupportedKxGroup>) {
+        self.crypto_provider
+            .get_or_insert_with(pingora_rustls::ring_default_crypto_provider)
+            .kx_groups = kx_groups;
+    }
+
     /// Configure mTLS by providing a rustls client certificate verifier.
     pub fn set_client_cert_verifier(&mut self, verifier: Arc<dyn ClientCertVerifier>) {
         self.client_cert_verifier = Some(verifier);
+    }
+
+    /// Require rustls to report FIPS mode for the generated server config.
+    pub fn set_require_fips(&mut self, require_fips: bool) {
+        self.require_fips = require_fips;
     }
 
     pub fn intermediate(cert_path: &str, key_path: &str) -> Result<Self>
@@ -104,9 +183,29 @@ impl TlsSettings {
     {
         Ok(TlsSettings {
             alpn_protocols: None,
+            protocol_versions: &TLS12_AND_13,
+            crypto_provider: None,
             cert_path: cert_path.to_string(),
             key_path: key_path.to_string(),
             client_cert_verifier: None,
+            cert_resolver: None,
+            require_fips: false,
+        })
+    }
+
+    pub fn with_cert_resolver(cert_resolver: Arc<dyn ResolvesServerCert>) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(TlsSettings {
+            alpn_protocols: None,
+            protocol_versions: &TLS12_AND_13,
+            crypto_provider: None,
+            cert_path: String::new(),
+            key_path: String::new(),
+            client_cert_verifier: None,
+            cert_resolver: Some(cert_resolver),
+            require_fips: false,
         })
     }
 
@@ -130,6 +229,34 @@ impl Acceptor {
             handshake_with_callback(self, stream, cb).await
         } else {
             handshake(self, stream).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_build_returns_error_when_required_fips_is_not_reported() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let cert_path = format!("{manifest_dir}/tests/keys/server.crt");
+        let key_path = format!("{manifest_dir}/tests/keys/key.pem");
+        let mut settings = TlsSettings::intermediate(&cert_path, &key_path).unwrap();
+        settings.set_crypto_provider(pingora_rustls::ring_default_crypto_provider());
+        settings.set_require_fips(true);
+
+        match settings.try_build() {
+            Ok(_) => panic!("expected non-FIPS rustls listener config to return an error"),
+            Err(error) => {
+                assert_eq!(error.etype(), &InternalError);
+                assert!(error
+                    .context
+                    .as_ref()
+                    .map(|context| context.as_str())
+                    .unwrap_or_default()
+                    .contains("does not report FIPS mode"));
+            }
         }
     }
 }

--- a/pingora-core/src/listeners/tls/s2n/mod.rs
+++ b/pingora-core/src/listeners/tls/s2n/mod.rs
@@ -99,6 +99,10 @@ impl TlsSettings {
         }
     }
 
+    pub fn try_build(self) -> Result<Acceptor> {
+        Ok(self.build())
+    }
+
     /// Enable HTTP/2 support for this endpoint, which is default off.
     /// This effectively sets the ALPN to prefer HTTP/2 with HTTP/1.1 allowed
     pub fn enable_h2(&mut self) {

--- a/pingora-core/src/protocols/tls/noop_tls/mod.rs
+++ b/pingora-core/src/protocols/tls/noop_tls/mod.rs
@@ -84,6 +84,10 @@ pub mod listeners {
             Acceptor
         }
 
+        pub fn try_build(&self) -> Result<Acceptor> {
+            Ok(self.build())
+        }
+
         pub fn intermediate(_: &str, _: &str) -> Result<Self> {
             Ok(Self)
         }

--- a/pingora-core/src/protocols/tls/rustls/stream.rs
+++ b/pingora-core/src/protocols/tls/rustls/stream.rs
@@ -29,7 +29,9 @@ use crate::utils::tls::get_organization_serial_bytes;
 use pingora_error::ErrorType::{AcceptError, ConnectError, InternalError, TLSHandshakeFailure};
 use pingora_error::{OkOrErr, OrErr, Result};
 use pingora_rustls::TlsStream as RusTlsStream;
-use pingora_rustls::{hash_certificate, NoDebug};
+use pingora_rustls::{
+    hash_certificate, hash_certificate_with_provider, CertificateHashProvider, NoDebug,
+};
 use pingora_rustls::{Accept, Connect, ServerName, TlsConnector};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use x509_parser::nom::AsBytes;
@@ -46,6 +48,7 @@ pub struct InnerStream<T> {
 pub struct TlsStream<T> {
     tls: InnerStream<T>,
     digest: Option<Arc<SslDigest>>,
+    cert_digest_hash: NoDebug<Option<&'static CertificateHashProvider>>,
     timing: TimingDigest,
 }
 
@@ -69,6 +72,7 @@ where
         Ok(TlsStream {
             tls,
             digest: None,
+            cert_digest_hash: None.into(),
             timing: Default::default(),
         })
     }
@@ -85,6 +89,7 @@ where
         Ok(TlsStream {
             tls,
             digest: None,
+            cert_digest_hash: acceptor.cert_digest_hash.into(),
             timing: Default::default(),
         })
     }
@@ -163,7 +168,7 @@ where
     pub(crate) async fn connect(&mut self) -> Result<()> {
         self.tls.connect().await?;
         self.timing.established_ts = SystemTime::now();
-        self.digest = self.tls.digest();
+        self.digest = self.tls.digest(*self.cert_digest_hash);
         Ok(())
     }
 
@@ -171,7 +176,7 @@ where
     pub(crate) async fn accept(&mut self) -> Result<()> {
         self.tls.accept().await?;
         self.timing.established_ts = SystemTime::now();
-        self.digest = self.tls.digest();
+        self.digest = self.tls.digest(*self.cert_digest_hash);
         Ok(())
     }
 }
@@ -307,8 +312,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> InnerStream<T> {
         Ok(())
     }
 
-    pub(crate) fn digest(&mut self) -> Option<Arc<SslDigest>> {
-        Some(Arc::new(SslDigest::from_stream(&self.stream)))
+    pub(crate) fn digest(
+        &mut self,
+        cert_digest_hash: Option<&'static CertificateHashProvider>,
+    ) -> Option<Arc<SslDigest>> {
+        Some(Arc::new(SslDigest::from_stream(
+            &self.stream,
+            cert_digest_hash,
+        )))
     }
 }
 
@@ -361,7 +372,10 @@ where
 }
 
 impl SslDigest {
-    fn from_stream<T>(stream: &Option<RusTlsStream<T>>) -> Self {
+    fn from_stream<T>(
+        stream: &Option<RusTlsStream<T>>,
+        cert_digest_hash: Option<&'static CertificateHashProvider>,
+    ) -> Self {
         let stream = stream.as_ref().unwrap();
         let (_io, session) = stream.get_ref();
         let protocol = session.protocol_version();
@@ -378,7 +392,10 @@ impl SslDigest {
 
         let cert_digest = peer_certificates
             .and_then(|certs| certs.first())
-            .map(|cert| hash_certificate(cert))
+            .map(|cert| match cert_digest_hash {
+                Some(hash_provider) => hash_certificate_with_provider(cert, hash_provider),
+                None => hash_certificate(cert),
+            })
             .unwrap_or_default();
 
         let (organization, serial_number) = peer_certificates

--- a/pingora-rustls/src/lib.rs
+++ b/pingora-rustls/src/lib.rs
@@ -26,11 +26,14 @@ pub use no_debug::{Ellipses, NoDebug, WithTypeInfo};
 use pingora_error::{Error, ErrorType, OrErr, Result};
 
 pub use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+pub use rustls::server::ResolvesServerCert;
 pub use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
 pub use rustls::{
-    client::WebPkiServerVerifier, crypto::CryptoProvider, version, CertificateError, ClientConfig,
-    DigitallySignedStruct, Error as RusTlsError, KeyLogFile, RootCertStore, ServerConfig,
-    SignatureScheme, Stream,
+    client::WebPkiServerVerifier,
+    crypto::{CryptoProvider, SupportedKxGroup},
+    version, CertificateError, ClientConfig, DigitallySignedStruct, Error as RusTlsError,
+    KeyLogFile, RootCertStore, ServerConfig, SignatureScheme, Stream, SupportedCipherSuite,
+    SupportedProtocolVersion,
 };
 
 /// Install the default `ring` CryptoProvider for rustls.
@@ -40,6 +43,11 @@ pub use rustls::{
 /// calls are no-ops.
 pub fn install_default_crypto_provider() {
     let _ = CryptoProvider::install_default(rustls::crypto::ring::default_provider());
+}
+
+/// Return rustls' default `ring` CryptoProvider.
+pub fn ring_default_crypto_provider() -> CryptoProvider {
+    rustls::crypto::ring::default_provider()
 }
 pub use rustls_native_certs::load_native_certs;
 use rustls_pemfile::Item;

--- a/pingora-rustls/src/lib.rs
+++ b/pingora-rustls/src/lib.rs
@@ -194,3 +194,24 @@ pub fn hash_certificate(cert: &CertificateDer) -> Vec<u8> {
     let hash = ring::digest::digest(&ring::digest::SHA256, cert.as_ref());
     hash.as_ref().to_vec()
 }
+
+pub type CertificateHashProvider = dyn rustls::crypto::hash::Hash;
+
+pub fn sha256_hash_provider(provider: &CryptoProvider) -> Option<&'static CertificateHashProvider> {
+    provider.cipher_suites.iter().find_map(|suite| {
+        let hash_provider = match suite {
+            SupportedCipherSuite::Tls12(suite) => suite.common.hash_provider,
+            SupportedCipherSuite::Tls13(suite) => suite.common.hash_provider,
+        };
+
+        (hash_provider.algorithm() == rustls::crypto::hash::HashAlgorithm::SHA256)
+            .then_some(hash_provider)
+    })
+}
+
+pub fn hash_certificate_with_provider(
+    cert: &CertificateDer,
+    hash_provider: &CertificateHashProvider,
+) -> Vec<u8> {
+    hash_provider.hash(cert.as_ref()).as_ref().to_vec()
+}


### PR DESCRIPTION
## Summary

This PR makes rustls listener construction able to report configuration failures through Pingora's normal `Result` path instead of requiring downstream users to panic when a listener policy cannot be satisfied.

It adds a fallible `TlsSettings::try_build()` method for rustls listeners and uses it when Pingora builds listener transport stacks. The existing `build()`  method remains available for compatibility and delegates to `try_build().unwrap()`, so existing direct callers keep the previous behavior.

The PR also exposes a small set of rustls server configuration hooks needed by applications that must select a specific rustls crypto provider or verify the resulting listener configuration.

## Motivation

rustls 0.23 requires an explicit `CryptoProvider`. Some downstream applications need to use a provider selected by policy rather than Pingora's default `ring` provider. One example is a deployment profile that builds rustls with the AWS-LC FIPS-capable provider and must fail closed if the final `ServerConfig` does not report `fips()`.

Before this change, Pingora's rustls listener path only exposed a panicking `build()` API. That makes policy enforcement awkward for applications that need startup to fail cleanly with structured context. The only practical downstream option was to keep a final panic assertion after normal provider and TLS policy checks.

This PR moves that failure into Pingora's normal error path.

## What Changed

- Added `TlsSettings::try_build() -> pingora_error::Result<Acceptor>` for rustls listeners.
- Kept `TlsSettings::build() -> Acceptor` for source compatibility. 
- Changed listener stack construction to call `try_build()` and propagate the error.
- Added rustls listener configuration hooks for:
  - explicit `CryptoProvider`
  - explicit ALPN protocol list
  - TLS 1.2 / TLS 1.3 minimum protocol selection
  - cipher suite selection
  - key exchange group selection
  - certificate resolver support
  - requiring the final `ServerConfig` to report FIPS mode
- Re-exported the needed rustls server/provider types from `pingora-rustls`.
- Added a regression test proving thatTitle:

## Compatibility

This is intended to be low risk for existing Pingora users:

- Existing `TlsSettings::intermediate(cert, key)` behavior is preserved.
- Existing `TlsSettings::build()` remains available.
- If no custom provider is configured, the rustls listener still installs/uses the default ring provider as before.
- Existing callers that do not opt into `set_require_fips(true)` are not subject to the new FIPS check.
- The new failure propagation only affects Pingora's own listener-stack build path by turning configuration failures into normal `Result` errors instead of panics.

## Why this is useful downstream

Downstream applications that have compliance-driven TLS requirements can now express those requirements through Pingora's rustls listener configuration and let Pingora fail startup cleanly if the resulting `rustls::ServerConfig` does not satisfy them.

This does not make Pingora itself enforce FIPS policy globally. It only provides the hooks and error propagation needed for applications to opt into that policy.

## Testing

- `cargo fmt`
- `cargo check -p pingora-core --features rustls`
- `cargo test -p pingora-core --features rustls try_build_returns_error_when_required_fips_is_not_reported`