### PR TITLE
chore: replace hand-rolled ascii trim helpers with stabilized std methods

### DIFF
--- a/pingora-core/src/protocols/http/compression/mod.rs
+++ b/pingora-core/src/protocols/http/compression/mod.rs
@@ -804,24 +804,7 @@ fn add_vary_header(resp: &mut ResponseHeader, value: &http::header::HeaderName) 
         existing
             .as_bytes()
             .split(|b| *b == b',')
-            .map(|mut v| {
-                // This is equivalent to slice.trim_ascii() which is unstable
-                while let [first, rest @ ..] = v {
-                    if first.is_ascii_whitespace() {
-                        v = rest;
-                    } else {
-                        break;
-                    }
-                }
-                while let [rest @ .., last] = v {
-                    if last.is_ascii_whitespace() {
-                        v = rest;
-                    } else {
-                        break;
-                    }
-                }
-                v
-            })
+            .map(|v| v.trim_ascii())
             .any(|v| v == b"*" || v.eq_ignore_ascii_case(value.as_ref()))
     });
 

--- a/pingora-core/src/protocols/http/conditional_filter.rs
+++ b/pingora-core/src/protocols/http/conditional_filter.rs
@@ -69,20 +69,6 @@ pub fn not_modified_filter(req: &RequestHeader, resp: &ResponseHeader) -> bool {
     false
 }
 
-// Trim ASCII whitespace bytes from the start of the slice.
-// This is pretty much copied from the nightly API.
-// TODO: use `trim_ascii_start` when it stabilizes https://doc.rust-lang.org/std/primitive.slice.html#method.trim_ascii_start
-fn trim_ascii_start(mut bytes: &[u8]) -> &[u8] {
-    while let [first, rest @ ..] = bytes {
-        if first.is_ascii_whitespace() {
-            bytes = rest;
-        } else {
-            break;
-        }
-    }
-    bytes
-}
-
 /// Search for an ETag matching `target_etag` from the input header, using
 /// [weak comparison](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3.2).
 /// Multiple ETags can exist in the header as a comma-separated list.
@@ -128,7 +114,7 @@ pub fn weak_validate_etag(input_etag_header: &[u8], target_etag: &[u8]) -> bool 
             remaining = &remaining[target_etag.len()..];
             // check if there's any content after the matched substring
             // skip any whitespace
-            remaining = trim_ascii_start(remaining);
+            remaining = remaining.trim_ascii_start();
             if matches!(remaining.first(), None | Some(b',')) {
                 // we are either at the end of the header, or at a comma delimiter
                 // which means this is a match


### PR DESCRIPTION
Both `trim_ascii_start` and `trim_ascii` were stabilized in Rust 1.80, and
the project MSRV is 1.84 - so we can drop the hand-rolled copies.

conditional_filter.rs had a local `trim_ascii_start` fn with a TODO
comment pointing at the stdlib method that was (then) unstable:
```rust
// TODO: use `trim_ascii_start` when it stabilizes
fn trim_ascii_start(mut bytes: &[u8]) -> &[u8] { ... }
```

**compression/mod.rs** had the same pattern inline with a comment:
```rust
// This is equivalent to slice.trim_ascii() which is unstable
while let [first, rest @ ..] = v { ... }
while let [rest @ .., last] = v { ... }
```

Both replaced with the one-liner stdlib calls. No behavior change, all
existing tests pass.