### PR TITLE
fix(load-balancing): avoid panic when all weighted backends have zero weight

### DIFF
--- a/pingora-load-balancing/src/selection/weighted.rs
+++ b/pingora-load-balancing/src/selection/weighted.rs
@@ -88,8 +88,11 @@ impl<H: SelectionAlgorithm> BackendIter for WeightedIterator<H> {
 
         if self.first {
             // initial hash, select from the weighted list
-            self.first = false;
             let len = self.backend.weighted.len();
+            if len == 0 {
+                return None;
+            }
+            self.first = false;
             let index = self.backend.weighted[self.index as usize % len];
             Some(&self.backend.backends[index as usize])
         } else {
@@ -148,6 +151,18 @@ mod test {
         assert_eq!(iter.next(), Some(&b2));
         let mut iter = hash.iter(b"test7");
         assert_eq!(iter.next(), Some(&b2));
+    }
+
+    #[test]
+    fn weighted_all_zero_weight_returns_none_instead_of_panicking() {
+        let b1 = Backend::new_with_weight("1.1.1.1:80", 0).unwrap();
+        let b2 = Backend::new_with_weight("1.0.0.1:80", 0).unwrap();
+        let backends = BTreeSet::from_iter([b1, b2]);
+        let hash: Arc<Weighted<FnvHasher>> = Arc::new(Weighted::build(&backends));
+
+        let mut iter = hash.iter(b"test");
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This fixes a panic in the weighted backend selector when the backend set is non-empty but every backend has weight `0`.

No issue is filed for this small, self-contained bug fix.

`Weighted::build()` builds the weighted index list by pushing each backend index `weight` times. If all backend weights are zero, `self.backend.backends` is non-empty but `self.backend.weighted` is empty.

The first call to `WeightedIterator::next()` only checks whether the backend list is empty, then uses `self.backend.weighted.len()` as the modulo divisor. When that length is zero, this panics.

## Fix

Return `None` from the initial weighted selection path when the weighted index list is empty.

This keeps the change limited to the all-zero-weight panic case. It does not change fallback behavior for mixed `weight = 0` / `weight > 0` backend sets, and it does not reject `weight = 0` in `Backend::new_with_weight()`.

## Test

Added a regression test covering two backends created with `Backend::new_with_weight(..., 0)`.

Before this change, the test panics with:

```text
attempt to calculate the remainder with a divisor of zero
```

After this change, selection returns `None`, and repeated calls on the same iterator continue returning `None`.

```bash
cargo test -p pingora-load-balancing weighted_all_zero_weight_returns_none_instead_of_panicking
```

Result:

```text
test selection::weighted::test::weighted_all_zero_weight_returns_none_instead_of_panicking ... ok
```
