### PR TITLE
fix: resolve #588 — Security Visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ libraries that must be satisfied in order to build them:
 [Clang]:https://clang.llvm.org/
 [Perl 5]:https://www.perl.org/
 
+# Security
+Please see our [security policy](./SECURITY.md) for how to report security vulnerabilities.
+
 # Contributing
 Please see our [contribution guidelines](./.github/CONTRIBUTING.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of Pingora seriously. If you believe you have found a security vulnerability, please report it to us privately. Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.
+
+Instead, please report them to the Cloudflare security team through one of the following channels:
+
+- Submit a report through HackerOne: https://hackerone.com/cloudflare
+- Email us at: security@cloudflare.com
+
+Please include as much of the following information as possible to help us better understand and resolve the issue:
+
+- The type of issue (e.g. buffer overflow, request smuggling, denial of service)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- The impact of the issue, including how an attacker might exploit it
+
+This information will help us triage your report more quickly.
+
+## Response and Disclosure
+
+The Cloudflare security team will acknowledge your report, investigate the issue, and determine its severity and the appropriate remediation timeline. We will keep you informed of our progress throughout the process.
+
+Once a fix is available, we will coordinate the release and public disclosure. We ask that you keep the details of any vulnerability confidential until a fix has been released.
+
+We appreciate your efforts to responsibly disclose your findings.


### PR DESCRIPTION
## Summary

Combined multi-file contribution:

## Changes

- `SECURITY.md` *(new)*
- `README.md`

## Why

`SECURITY.md`: The issue asks how the project handles security issues, how they're communicated to consumers, and who determines remediation timelines. The repository currently has no SECURITY.md, so there is no documented process for reporting or tracking vulnerabilities. GitHub surfaces a SECURITY.md automatically (in the "Security" tab and when a user opens an issue), making it the canonical place to answer these questions. Adding this file gives consumers a clear, discoverable channel for private disclosure and sets expectations around response and communication.
