### PR TITLE
fix(proxy): concatenate HTTP/2 Cookie headers when proxying to HTTP/1.1 (RFC 9113 §8.2.3)

### DIFF
--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -447,6 +447,15 @@ pub struct PeerOptions {
     /// **Note:** This field is unstable and may be removed or changed in future versions.
     /// It exists primarily for compatibility with legacy servers that send malformed headers.
     pub allow_h1_response_invalid_content_length: bool,
+    /// Concatenate multiple HTTP/2 `Cookie` headers into a single header when proxying to
+    /// an HTTP/1.1 upstream, as required by RFC 9113 §8.2.3.
+    ///
+    /// When enabled (default), multiple `Cookie` header fields received over HTTP/2 are
+    /// concatenated into a single `Cookie` header using `"; "` as the delimiter before
+    /// forwarding to an HTTP/1.1 upstream.
+    ///
+    /// Set to `false` to preserve the original multiple `Cookie` headers as-is.
+    pub h2_to_h1_concat_cookies: bool,
     pub extra_proxy_headers: BTreeMap<String, Vec<u8>>,
     /// The list of curves the tls connection should advertise
     /// if `None`, the default curves will be used
@@ -504,6 +513,7 @@ impl PeerOptions {
             h2_stream_window_size: None,
             h2_connection_window_size: None,
             allow_h1_response_invalid_content_length: false,
+            h2_to_h1_concat_cookies: true,
             extra_proxy_headers: BTreeMap::new(),
             curves: None,
             second_keyshare: true, // default true and noop when not using PQ curves

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -31,7 +31,9 @@ use pingora_core::protocols::http::custom::CUSTOM_MESSAGE_QUEUE_SIZE;
 ///
 /// The concatenation preserves the original insertion order of cookie values.
 fn h2_to_h1_concat_cookie_headers(req: &mut RequestHeader) {
-    let cookie_values: Vec<HeaderValue> = req.headers.get_all(header::COOKIE)
+    let cookie_values: Vec<HeaderValue> = req
+        .headers
+        .get_all(header::COOKIE)
         .into_iter()
         .cloned()
         .collect();
@@ -50,8 +52,7 @@ fn h2_to_h1_concat_cookie_headers(req: &mut RequestHeader) {
     req.remove_header(&header::COOKIE);
     let header_value = HeaderValue::from_maybe_shared(merged.freeze())
         .expect("concatenated cookie value is invalid");
-    req.insert_header(header::COOKIE, header_value)
-        .unwrap();
+    req.insert_header(header::COOKIE, header_value).unwrap();
 }
 
 impl<SV, C> HttpProxy<SV, C>
@@ -1129,7 +1130,10 @@ mod tests {
         assert_eq!(cookie.as_bytes(), b"a=1; b=2");
 
         let count = req.headers.get_all(header::COOKIE).into_iter().count();
-        assert_eq!(count, 1, "should have exactly one Cookie header after concatenation");
+        assert_eq!(
+            count, 1,
+            "should have exactly one Cookie header after concatenation"
+        );
     }
 
     #[test]

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -12,14 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::BytesMut;
 use futures::future::OptionFuture;
 use futures::StreamExt;
+use http::header::HeaderValue;
 
 use super::*;
 use crate::proxy_cache::{range_filter::RangeBodyFilter, ServeFromCache};
 use crate::proxy_common::*;
 use pingora_cache::CachePhase;
 use pingora_core::protocols::http::custom::CUSTOM_MESSAGE_QUEUE_SIZE;
+
+/// Concatenate multiple HTTP/2 `Cookie` headers into a single header for HTTP/1.1.
+///
+/// RFC 9113 §8.2.3 requires that multiple `Cookie` header fields received over HTTP/2
+/// MUST be concatenated into a single octet string using `"; "` (0x3B 0x20) as the
+/// delimiter before being passed into a non-HTTP/2 context.
+///
+/// The concatenation preserves the original insertion order of cookie values.
+fn h2_to_h1_concat_cookie_headers(req: &mut RequestHeader) {
+    let cookie_values: Vec<HeaderValue> = req.headers.get_all(header::COOKIE)
+        .into_iter()
+        .cloned()
+        .collect();
+    if cookie_values.len() <= 1 {
+        return;
+    }
+
+    let mut merged = BytesMut::new();
+    for (i, value) in cookie_values.iter().enumerate() {
+        if i > 0 {
+            merged.extend_from_slice(b"; ");
+        }
+        merged.extend_from_slice(value.as_bytes());
+    }
+
+    req.remove_header(&header::COOKIE);
+    let header_value = HeaderValue::from_maybe_shared(merged.freeze())
+        .expect("concatenated cookie value is invalid");
+    req.insert_header(header::COOKIE, header_value)
+        .unwrap();
+}
 
 impl<SV, C> HttpProxy<SV, C>
 where
@@ -59,7 +92,11 @@ where
                 let host = req.uri.authority().map_or("", |a| a.as_str()).to_owned();
                 req.insert_header(header::HOST, host).unwrap();
             }
-            // TODO: Add keepalive header for connection reuse, but this is not required per RFC
+            // RFC 9113 §8.2.3: Concatenate multiple Cookie headers into a single header
+            // when forwarding to a non-HTTP/2 context.
+            if peer.options.h2_to_h1_concat_cookies {
+                h2_to_h1_concat_cookie_headers(&mut req);
+            }
         }
 
         if session.cache.enabled() {
@@ -1025,5 +1062,82 @@ pub(crate) async fn send_body_to1(
         }
     } else {
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_request_with_cookies(cookies: &[&str]) -> RequestHeader {
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        for cookie in cookies {
+            req.append_header(header::COOKIE, *cookie).unwrap();
+        }
+        req
+    }
+
+    #[test]
+    fn test_concat_multiple_cookies() {
+        let mut req = build_request_with_cookies(&["a=1", "b=2", "c=3"]);
+        h2_to_h1_concat_cookie_headers(&mut req);
+
+        let cookie = req.headers.get(header::COOKIE).unwrap();
+        assert_eq!(cookie.as_bytes(), b"a=1; b=2; c=3");
+    }
+
+    #[test]
+    fn test_concat_preserves_order() {
+        let mut req = build_request_with_cookies(&[
+            "preferred_language=ko",
+            "_gitlab_session=abc123",
+            "sidebar=collapsed",
+        ]);
+        h2_to_h1_concat_cookie_headers(&mut req);
+
+        let cookie = req.headers.get(header::COOKIE).unwrap();
+        assert_eq!(
+            cookie.as_bytes(),
+            b"preferred_language=ko; _gitlab_session=abc123; sidebar=collapsed"
+        );
+    }
+
+    #[test]
+    fn test_concat_single_cookie_unchanged() {
+        let mut req = build_request_with_cookies(&["session=xyz"]);
+        h2_to_h1_concat_cookie_headers(&mut req);
+
+        let values: Vec<_> = req.headers.get_all(header::COOKIE).into_iter().collect();
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].as_bytes(), b"session=xyz");
+    }
+
+    #[test]
+    fn test_concat_no_cookies_is_noop() {
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        h2_to_h1_concat_cookie_headers(&mut req);
+
+        assert!(req.headers.get(header::COOKIE).is_none());
+    }
+
+    #[test]
+    fn test_concat_two_cookies() {
+        let mut req = build_request_with_cookies(&["a=1", "b=2"]);
+        h2_to_h1_concat_cookie_headers(&mut req);
+
+        let cookie = req.headers.get(header::COOKIE).unwrap();
+        assert_eq!(cookie.as_bytes(), b"a=1; b=2");
+
+        let count = req.headers.get_all(header::COOKIE).into_iter().count();
+        assert_eq!(count, 1, "should have exactly one Cookie header after concatenation");
+    }
+
+    #[test]
+    fn test_concat_cookies_with_semicolons() {
+        let mut req = build_request_with_cookies(&["a=1; b=2", "c=3"]);
+        h2_to_h1_concat_cookie_headers(&mut req);
+
+        let cookie = req.headers.get(header::COOKIE).unwrap();
+        assert_eq!(cookie.as_bytes(), b"a=1; b=2; c=3");
     }
 }


### PR DESCRIPTION
## Summary

Implements Cookie header concatenation when proxying HTTP/2 requests to HTTP/1.1 upstreams, as required by RFC 9113 §8.2.3.

Fixes #892

## Problem

When a browser sends cookies over HTTP/2, it may split them into separate `Cookie` header fields for better HPACK compression (permitted by RFC 9113 §8.2.3). Pingora currently forwards these as separate header lines to HTTP/1.1 upstreams. Many backends only read the first `Cookie` header, causing session cookies to be silently dropped — leading to failures such as CSRF token verification errors (HTTP 422 on GitLab, for example).

## Changes

- **`pingora-proxy/src/proxy_h1.rs`**: Add `h2_to_h1_concat_cookie_headers()` that merges multiple `Cookie` headers into one using `"; "` as delimiter, preserving insertion order. Called during H2→H1 conversion in `proxy_1to1()`.
- **`pingora-core/src/upstreams/peer.rs`**: Add `PeerOptions.h2_to_h1_concat_cookies` flag (default: `true`) to allow disabling the behavior if needed.

## Test plan

- [x] `test_concat_multiple_cookies` — 3 cookies merged correctly
- [x] `test_concat_preserves_order` — GitLab CSRF scenario (order preserved)
- [x] `test_concat_single_cookie_unchanged` — single cookie untouched
- [x] `test_concat_no_cookies_is_noop` — no cookies, no changes
- [x] `test_concat_two_cookies` — 2 cookies merged, result is exactly 1 header
- [x] `test_concat_cookies_with_semicolons` — cookie values already containing `; ` handled correctly
- [x] `cargo check -p pingora-proxy -p pingora-core` passes
- [x] All 6 new tests pass