### PR TITLE
TlsAcceptCallbacks support for rustls backend

### DIFF
--- a/pingora-core/src/listeners/tls/rustls/mod.rs
+++ b/pingora-core/src/listeners/tls/rustls/mod.rs
@@ -17,10 +17,11 @@ use std::sync::Arc;
 use crate::listeners::TlsAcceptCallbacks;
 use crate::protocols::tls::{server::handshake, server::handshake_with_callback, TlsStream};
 use log::debug;
-use pingora_error::ErrorType::InternalError;
+use pingora_error::ErrorType::{InternalError, InvalidCert};
 use pingora_error::{Error, OrErr, Result};
 use pingora_rustls::load_certs_and_key_files;
 use pingora_rustls::ClientCertVerifier;
+use pingora_rustls::ResolvesServerCert;
 use pingora_rustls::ServerConfig;
 use pingora_rustls::{version, TlsAcceptor as RusTlsAcceptor};
 
@@ -31,7 +32,9 @@ pub struct TlsSettings {
     alpn_protocols: Option<Vec<Vec<u8>>>,
     cert_path: String,
     key_path: String,
+    cert_resolver: Option<Arc<dyn ResolvesServerCert>>,
     client_cert_verifier: Option<Arc<dyn ClientCertVerifier>>,
+    callbacks: Option<TlsAcceptCallbacks>,
 }
 
 pub struct Acceptor {
@@ -51,14 +54,6 @@ impl TlsSettings {
         // rustls 0.23+ requires an explicit CryptoProvider.
         pingora_rustls::install_default_crypto_provider();
 
-        let Ok(Some((certs, key))) = load_certs_and_key_files(&self.cert_path, &self.key_path)
-        else {
-            panic!(
-                "Failed to load provided certificates \"{}\" or key \"{}\".",
-                self.cert_path, self.key_path
-            )
-        };
-
         let builder =
             ServerConfig::builder_with_protocol_versions(&[&version::TLS12, &version::TLS13]);
         let builder = if let Some(verifier) = self.client_cert_verifier {
@@ -66,12 +61,31 @@ impl TlsSettings {
         } else {
             builder.with_no_client_auth()
         };
-        let mut config = builder
-            .with_single_cert(certs, key)
-            .explain_err(InternalError, |e| {
-                format!("Failed to create server listener config: {e}")
-            })
-            .unwrap();
+
+        let mut config = if let Some(resolver) = self.cert_resolver {
+            builder.with_cert_resolver(resolver)
+        } else {
+            assert!(
+                !self.cert_path.is_empty() && !self.key_path.is_empty(),
+                "Either set_cert_resolver() or both set_certificate_chain_file() and \
+                 set_private_key_file() must be called before build()."
+            );
+
+            let Ok(Some((certs, key))) = load_certs_and_key_files(&self.cert_path, &self.key_path)
+            else {
+                panic!(
+                    "Failed to load provided certificates \"{}\" or key \"{}\".",
+                    self.cert_path, self.key_path
+                )
+            };
+
+            builder
+                .with_single_cert(certs, key)
+                .explain_err(InternalError, |e| {
+                    format!("Failed to create server listener config: {e}")
+                })
+                .unwrap()
+        };
 
         if let Some(alpn_protocols) = self.alpn_protocols {
             config.alpn_protocols = alpn_protocols;
@@ -79,7 +93,7 @@ impl TlsSettings {
 
         Acceptor {
             acceptor: RusTlsAcceptor::from(Arc::new(config)),
-            callbacks: None,
+            callbacks: self.callbacks,
         }
     }
 
@@ -98,6 +112,43 @@ impl TlsSettings {
         self.client_cert_verifier = Some(verifier);
     }
 
+    /// Install a user-provided server certificate resolver.
+    ///
+    /// When set, any certificate/key paths are ignored at `build()`. Useful for
+    /// dynamic SNI-based selection, where the cert cannot be chosen ahead of the
+    /// handshake.
+    pub fn set_cert_resolver(&mut self, resolver: Arc<dyn ResolvesServerCert>) {
+        self.cert_resolver = Some(resolver);
+    }
+
+    /// Set the path to the certificate chain file (PEM format).
+    ///
+    /// Returns an error if the file cannot be opened or contains no X.509
+    /// certificate, matching the OpenSSL backend's behavior.
+    pub fn set_certificate_chain_file(&mut self, path: &str) -> Result<()> {
+        let path_str = path.to_string();
+        let bytes = pingora_rustls::load_pem_file_ca(&path_str)?;
+        if bytes.is_empty() {
+            return Error::e_explain(InvalidCert, format!("No X.509 certificate found in {path}"));
+        }
+        self.cert_path = path_str;
+        Ok(())
+    }
+
+    /// Set the path to the private key file (PEM format).
+    ///
+    /// Returns an error if the file cannot be opened or contains no private
+    /// key, matching the OpenSSL backend's behavior.
+    pub fn set_private_key_file(&mut self, path: &str) -> Result<()> {
+        let path_str = path.to_string();
+        let bytes = pingora_rustls::load_pem_file_private_key(&path_str)?;
+        if bytes.is_empty() {
+            return Error::e_explain(InvalidCert, format!("No private key found in {path}"));
+        }
+        self.key_path = path_str;
+        Ok(())
+    }
+
     pub fn intermediate(cert_path: &str, key_path: &str) -> Result<Self>
     where
         Self: Sized,
@@ -106,19 +157,29 @@ impl TlsSettings {
             alpn_protocols: None,
             cert_path: cert_path.to_string(),
             key_path: key_path.to_string(),
+            cert_resolver: None,
             client_cert_verifier: None,
+            callbacks: None,
         })
     }
 
-    pub fn with_callbacks() -> Result<Self>
+    /// Create a new [`TlsSettings`] with post-handshake callbacks.
+    ///
+    /// Before calling `build()`, supply either a cert/key pair via
+    /// `set_certificate_chain_file` + `set_private_key_file`, or a custom
+    /// resolver via `set_cert_resolver`.
+    pub fn with_callbacks(callbacks: TlsAcceptCallbacks) -> Result<Self>
     where
         Self: Sized,
     {
-        // TODO: verify if/how callback in handshake can be done using Rustls
-        Error::e_explain(
-            InternalError,
-            "Certificate callbacks are not supported with feature \"rustls\".",
-        )
+        Ok(TlsSettings {
+            alpn_protocols: None,
+            cert_path: String::new(),
+            key_path: String::new(),
+            cert_resolver: None,
+            client_cert_verifier: None,
+            callbacks: Some(callbacks),
+        })
     }
 }
 

--- a/pingora-core/src/protocols/tls/rustls/mod.rs
+++ b/pingora-core/src/protocols/tls/rustls/mod.rs
@@ -19,7 +19,51 @@ mod stream;
 pub use stream::*;
 
 use crate::utils::tls::WrappedX509;
+use pingora_rustls::CertificateDer;
 
 pub type CaType = [WrappedX509];
 
-pub struct TlsRef;
+/// TLS connection state exposed to post-handshake callbacks.
+///
+/// Provides access to peer certificates and negotiated cipher suite
+/// after a TLS handshake completes. This is the rustls equivalent of
+/// the OpenSSL `SslRef` that is used as `TlsRef` in the boringssl/openssl path.
+#[derive(Debug)]
+pub struct TlsRef {
+    pub(super) peer_certs: Option<Vec<CertificateDer<'static>>>,
+    pub(super) cipher: Option<&'static str>,
+    pub(super) version: Option<&'static str>,
+    pub(super) server_name: Option<String>,
+}
+
+impl TlsRef {
+    /// Returns the peer's leaf certificate in DER encoding, if present.
+    pub fn peer_certificate_der(&self) -> Option<&[u8]> {
+        self.peer_certs
+            .as_ref()
+            .and_then(|certs| certs.first())
+            .map(|cert| cert.as_ref())
+    }
+
+    /// Returns the full peer certificate chain in DER encoding.
+    /// The first entry is the leaf; subsequent entries are intermediates.
+    pub fn peer_cert_chain_der(&self) -> Option<&[CertificateDer<'static>]> {
+        self.peer_certs.as_deref()
+    }
+
+    /// Returns the negotiated cipher suite name, if available.
+    pub fn current_cipher_name(&self) -> Option<&'static str> {
+        self.cipher
+    }
+
+    /// Returns the negotiated TLS protocol version (e.g. "TLSv1.3"), if available.
+    pub fn version(&self) -> Option<&'static str> {
+        self.version
+    }
+
+    /// Returns the SNI hostname sent by the peer, if any. Only populated on
+    /// server-side connections; always `None` on client streams.
+    pub fn server_name(&self) -> Option<&str> {
+        self.server_name.as_deref()
+    }
+}

--- a/pingora-core/src/protocols/tls/rustls/server.rs
+++ b/pingora-core/src/protocols/tls/rustls/server.rs
@@ -16,8 +16,7 @@
 
 use crate::listeners::TlsAcceptCallbacks;
 use crate::protocols::tls::rustls::TlsStream;
-use crate::protocols::tls::TlsRef;
-use crate::protocols::IO;
+use crate::protocols::{Ssl, IO};
 use crate::{listeners::tls::Acceptor, protocols::Shutdown};
 use async_trait::async_trait;
 use log::warn;
@@ -65,7 +64,6 @@ pub async fn handshake<S: IO>(acceptor: &Acceptor, io: S) -> Result<TlsStream<S>
 }
 
 /// Perform TLS handshake for the given connection with the given configuration and callbacks
-/// callbacks are currently not supported within pingora Rustls and are ignored
 pub async fn handshake_with_callback<S: IO>(
     acceptor: &Acceptor,
     io: S,
@@ -74,20 +72,21 @@ pub async fn handshake_with_callback<S: IO>(
     let mut tls_stream = prepare_tls_stream(acceptor, io).await?;
     let done = Pin::new(&mut tls_stream).start_accept().await?;
     if !done {
-        // TODO: verify if/how callback in handshake can be done using Rustls
-        warn!("Callacks are not supported with feature \"rustls\".");
-
+        // NOTE: certificate_callback is not invoked for rustls. Dynamic cert selection
+        // should use a custom ResolvesServerCert instead.
+        warn!("certificate_callback is not supported with the rustls backend; use ResolvesServerCert for dynamic cert selection");
         Pin::new(&mut tls_stream)
             .resume_accept()
             .await
             .explain_err(TLSHandshakeFailure, |e| format!("TLS accept() failed: {e}"))?;
     }
-    {
-        let tls_ref = TlsRef;
-        if let Some(extension) = callbacks.handshake_complete_callback(&tls_ref).await {
-            if let Some(digest_mut) = tls_stream.ssl_digest_mut() {
-                digest_mut.extension.set(extension);
-            }
+    let extension = match tls_stream.get_ssl() {
+        Some(tls_ref) => callbacks.handshake_complete_callback(tls_ref).await,
+        None => None,
+    };
+    if let Some(extension) = extension {
+        if let Some(digest_mut) = tls_stream.ssl_digest_mut() {
+            digest_mut.extension.set(extension);
         }
     }
     Ok(tls_stream)
@@ -108,8 +107,100 @@ where
     }
 }
 
-#[ignore]
-#[tokio::test]
-async fn test_async_cert() {
-    todo!("callback support and test for Rustls")
+#[cfg(test)]
+mod tests {
+    use crate::listeners::tls::TlsSettings;
+    use crate::listeners::TlsAccept;
+    use crate::protocols::tls::TlsRef;
+    use async_trait::async_trait;
+    use pingora_rustls::{
+        ClientConfig, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerName,
+    };
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, DuplexStream};
+
+    #[derive(Debug)]
+    struct NoVerify;
+
+    impl ServerCertVerifier for NoVerify {
+        fn verify_server_cert(
+            &self,
+            _: &rustls::pki_types::CertificateDer<'_>,
+            _: &[rustls::pki_types::CertificateDer<'_>],
+            _: &ServerName<'_>,
+            _: &[u8],
+            _: pingora_rustls::UnixTime,
+        ) -> Result<ServerCertVerified, rustls::Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _: &[u8],
+            _: &rustls::pki_types::CertificateDer<'_>,
+            _: &rustls::DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _: &[u8],
+            _: &rustls::pki_types::CertificateDer<'_>,
+            _: &rustls::DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            rustls::crypto::ring::default_provider()
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+
+    async fn client_task(client: DuplexStream) {
+        let config = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify))
+            .with_no_client_auth();
+        let connector = pingora_rustls::TlsConnector::from(Arc::new(config));
+        let server_name = ServerName::try_from("openrusty.org").unwrap();
+        let mut stream = connector.connect(server_name, client).await.unwrap();
+        let mut buf = [0u8; 1];
+        let _ = stream.read(&mut buf).await;
+    }
+
+    #[tokio::test]
+    async fn test_handshake_complete_callback() {
+        struct CipherName(String);
+        struct Callback;
+
+        #[async_trait]
+        impl TlsAccept for Callback {
+            async fn handshake_complete_callback(
+                &self,
+                tls: &TlsRef,
+            ) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+                let name = tls.current_cipher_name()?.to_string();
+                Some(Arc::new(CipherName(name)))
+            }
+        }
+
+        let cert = format!("{}/tests/keys/server.crt", env!("CARGO_MANIFEST_DIR"));
+        let key = format!("{}/tests/keys/key.pem", env!("CARGO_MANIFEST_DIR"));
+
+        let mut settings = TlsSettings::with_callbacks(Box::new(Callback)).unwrap();
+        settings.set_certificate_chain_file(&cert).unwrap();
+        settings.set_private_key_file(&key).unwrap();
+        let acceptor = settings.build();
+
+        let (client, server) = tokio::io::duplex(4096);
+        tokio::spawn(client_task(client));
+
+        let stream = acceptor.tls_handshake(server).await.unwrap();
+        let digest = stream.ssl_digest().unwrap();
+        let cipher = digest.extension.get::<CipherName>().unwrap();
+        assert!(!cipher.0.is_empty());
+    }
 }

--- a/pingora-core/src/protocols/tls/rustls/stream.rs
+++ b/pingora-core/src/protocols/tls/rustls/stream.rs
@@ -21,6 +21,7 @@ use std::time::{Duration, SystemTime};
 
 use crate::listeners::tls::Acceptor;
 use crate::protocols::raw_connect::ProxyDigest;
+use crate::protocols::tls::TlsRef;
 use crate::protocols::{tls::SslDigest, Peek, TimingDigest, UniqueIDType};
 use crate::protocols::{
     GetProxyDigest, GetSocketDigest, GetTimingDigest, SocketDigest, Ssl, UniqueID, ALPN,
@@ -46,6 +47,7 @@ pub struct InnerStream<T> {
 pub struct TlsStream<T> {
     tls: InnerStream<T>,
     digest: Option<Arc<SslDigest>>,
+    ssl: Option<TlsRef>,
     timing: TimingDigest,
 }
 
@@ -69,6 +71,7 @@ where
         Ok(TlsStream {
             tls,
             digest: None,
+            ssl: None,
             timing: Default::default(),
         })
     }
@@ -85,6 +88,7 @@ where
         Ok(TlsStream {
             tls,
             digest: None,
+            ssl: None,
             timing: Default::default(),
         })
     }
@@ -164,6 +168,7 @@ where
         self.tls.connect().await?;
         self.timing.established_ts = SystemTime::now();
         self.digest = self.tls.digest();
+        self.ssl = self.tls.tls_ref();
         Ok(())
     }
 
@@ -172,6 +177,7 @@ where
         self.tls.accept().await?;
         self.timing.established_ts = SystemTime::now();
         self.digest = self.tls.digest();
+        self.ssl = self.tls.tls_ref();
         Ok(())
     }
 }
@@ -228,6 +234,10 @@ where
 }
 
 impl<T> Ssl for TlsStream<T> {
+    fn get_ssl(&self) -> Option<&TlsRef> {
+        self.ssl.as_ref()
+    }
+
     fn get_ssl_digest(&self) -> Option<Arc<SslDigest>> {
         self.ssl_digest()
     }
@@ -309,6 +319,26 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> InnerStream<T> {
 
     pub(crate) fn digest(&mut self) -> Option<Arc<SslDigest>> {
         Some(Arc::new(SslDigest::from_stream(&self.stream)))
+    }
+
+    pub(crate) fn tls_ref(&self) -> Option<TlsRef> {
+        let stream = self.stream.as_ref()?;
+        let (_io, session) = stream.get_ref();
+        let peer_certs = session.peer_certificates().map(|certs| certs.to_vec());
+        let cipher = session
+            .negotiated_cipher_suite()
+            .and_then(|suite| suite.suite().as_str());
+        let version = session.protocol_version().and_then(|v| v.as_str());
+        let server_name = match stream {
+            RusTlsStream::Server(s) => s.get_ref().1.server_name().map(|n| n.to_string()),
+            RusTlsStream::Client(_) => None,
+        };
+        Some(TlsRef {
+            peer_certs,
+            cipher,
+            version,
+            server_name,
+        })
     }
 }
 

--- a/pingora-rustls/src/lib.rs
+++ b/pingora-rustls/src/lib.rs
@@ -26,7 +26,10 @@ pub use no_debug::{Ellipses, NoDebug, WithTypeInfo};
 use pingora_error::{Error, ErrorType, OrErr, Result};
 
 pub use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
-pub use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
+pub use rustls::server::{
+    ClientCertVerifierBuilder, ClientHello, ResolvesServerCert, WebPkiClientVerifier,
+};
+pub use rustls::sign;
 pub use rustls::{
     client::WebPkiServerVerifier, crypto::CryptoProvider, version, CertificateError, ClientConfig,
     DigitallySignedStruct, Error as RusTlsError, KeyLogFile, RootCertStore, ServerConfig,


### PR DESCRIPTION
Support TlsAcceptCallbacks for the rustls backend

Ports the `TlsAcceptCallbacks` support from upstream https://github.com/cloudflare/pingora/pull/833, excluding the parts flagged in review there: that PR bundles unrelated changes (intentional webpki policy bypass on cert loading, custom ServerCertVerifier support in the connector) which @nojima asked to split into a separate PR (https://github.com/cloudflare/pingora/pull/833#issuecomment-4322312620) for independent security discussion. This PR takes only the callbacks feature.

Changes
• `TlsSettings::with_callbacks(cb)` now works with rustls (previously returned an error); added `set_certificate_chain_file()` / `set_private_key_file()` and `set_cert_resolver()` for dynamic cert selection
• `TlsRef` extended from an empty struct to expose post-handshake state.
• `handshake_with_callback()` passes a populated `TlsRef` to `handshake_complete_callback`, matching the OpenSSL/BoringSSL behavior
• Added `test_handshake_complete_callback` integration test

Deviations from #833
• No webpki bypass: cert/key loading still goes through with_single_cert()
• Test uses the ring provider instead of aws_lc_rs