### PR TITLE
fix: avoid panics by removing unwraps during HttpPeer DNS resolution

### DIFF
--- a/pingora-core/src/connectors/http/v1.rs
+++ b/pingora-core/src/connectors/http/v1.rs
@@ -98,7 +98,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect() {
         let connector = Connector::new(None);
-        let peer = HttpPeer::new(("1.1.1.1", 80), false, "".into());
+        let peer = HttpPeer::new(("1.1.1.1", 80), false, "".into()).unwrap();
         // make a new connection to 1.1.1.1
         let (http, reused) = connector.get_http_session(&peer).await.unwrap();
         let server_addr = http.server_addr().unwrap();
@@ -156,7 +156,7 @@ mod tests {
         }
 
         let connector = Connector::new(None);
-        let peer = HttpPeer::new(("1.1.1.1", 80), false, "".into());
+        let peer = HttpPeer::new(("1.1.1.1", 80), false, "".into()).unwrap();
         let (mut http, reused) = connector.get_http_session(&peer).await.unwrap();
         assert!(!reused);
         get_http(&mut http, 301).await;

--- a/pingora-core/src/connectors/http/v2.rs
+++ b/pingora-core/src/connectors/http/v2.rs
@@ -689,7 +689,7 @@ mod tests {
     #[tokio::test]
     async fn test_connect_h1_plaintext() {
         let connector = Connector::new(None);
-        let mut peer = HttpPeer::new(("1.1.1.1", 80), false, "".into());
+        let mut peer = HttpPeer::new(("1.1.1.1", 80), false, "".into()).unwrap();
         peer.options.set_http_version(2, 1);
         let h2 = connector
             .new_http_session::<HttpPeer, ()>(&peer)

--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -355,7 +355,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_conn_error_addr_not_avail() {
-        let peer = HttpPeer::new("127.0.0.1:121".to_string(), false, "".to_string());
+        let peer = HttpPeer::new("127.0.0.1:121".to_string(), false, "".to_string()).unwrap();
         let addr = "192.0.2.2:0".parse().ok();
         let bind_to = BindTo {
             addr,
@@ -367,7 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_conn_error_other() {
-        let peer = HttpPeer::new("240.0.0.1:80".to_string(), false, "".to_string()); // non localhost
+        let peer = HttpPeer::new("240.0.0.1:80".to_string(), false, "".to_string()).unwrap(); // non localhost
         let addr = "127.0.0.1:0".parse().ok();
         // create an error: cannot send from src addr: localhost to dst addr: a public IP
         let bind_to = BindTo {
@@ -447,7 +447,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_connect_proxy_fail() {
-        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
+        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string()).unwrap();
         let mut path = PathBuf::new();
         path.push("/tmp/123");
         peer.proxy = Some(Proxy {
@@ -474,7 +474,7 @@ mod tests {
         // Wait for the server to be ready
         ready_rx.await.unwrap();
 
-        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
+        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string()).unwrap();
         let mut path = PathBuf::new();
         path.push(&socket_path);
         peer.proxy = Some(Proxy {
@@ -503,7 +503,7 @@ mod tests {
         // Wait for the server to be ready
         ready_rx.await.unwrap();
 
-        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string());
+        let mut peer = HttpPeer::new("1.1.1.1:80".to_string(), false, "".to_string()).unwrap();
         let mut path = PathBuf::new();
         path.push(&socket_path);
         peer.proxy = Some(Proxy {
@@ -574,7 +574,7 @@ mod tests {
         let (low, _) = get_ip_local_port_range();
         let high = low + 1;
 
-        let peer = HttpPeer::new(format!("127.0.0.1:{port}"), false, "".to_string());
+        let peer = HttpPeer::new(format!("127.0.0.1:{port}"), false, "".to_string()).unwrap();
         let mut bind_to = BindTo {
             addr: "127.0.0.1:0".parse().ok(),
             ..Default::default()

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -27,6 +27,7 @@ use crate::protocols::TcpKeepalive;
 use crate::utils::tls::{get_organization_unit, CertKey};
 use ahash::AHasher;
 use derivative::Derivative;
+use pingora_error::{Error, ErrorType};
 use pingora_error::{
     ErrorType::{InternalError, SocketError},
     OrErr, Result,
@@ -701,10 +702,18 @@ impl HttpPeer {
     }
 
     /// Create a new [`HttpPeer`] with the given socket address and TLS settings.
-    pub fn new<A: ToInetSocketAddrs>(address: A, tls: bool, sni: String) -> Self {
-        let mut addrs_iter = address.to_socket_addrs().unwrap(); //TODO: handle error
-        let addr = addrs_iter.next().unwrap();
-        Self::new_from_sockaddr(SocketAddr::Inet(addr), tls, sni)
+    pub fn new<A: ToInetSocketAddrs>(address: A, tls: bool, sni: String) -> Result<Self> {
+        let mut addrs_iter = address.to_socket_addrs().map_err(|e| {
+            Error::explain(
+                ErrorType::Custom("Failed to resolve IP address"),
+                e.to_string(),
+            )
+        })?;
+        let addr = addrs_iter.next().ok_or(Error::explain(
+            ErrorType::Custom("No IP address found for the given host"),
+            "The address resolution iterator returned an empty list.",
+        ))?;
+        Ok(Self::new_from_sockaddr(SocketAddr::Inet(addr), tls, sni))
     }
 
     /// Create a new [`HttpPeer`] with the given path to Unix domain socket and TLS settings.
@@ -747,10 +756,10 @@ impl HttpPeer {
         address: A,
         sni: String,
         client_cert_key: Arc<CertKey>,
-    ) -> Self {
-        let mut peer = Self::new(address, true, sni);
+    ) -> Result<Self> {
+        let mut peer = Self::new(address, true, sni)?;
         peer.client_cert_key = Some(client_cert_key);
-        peer
+        Ok(peer)
     }
 
     fn peer_hash(&self) -> u64 {

--- a/pingora-load-balancing/src/health_check.rs
+++ b/pingora-load-balancing/src/health_check.rs
@@ -199,14 +199,14 @@ impl HttpHealthCheck<()> {
     /// * consecutive_failure: 1
     /// * reuse_connection: false
     /// * validator: `None`, any 200 response is considered successful
-    pub fn new(host: &str, tls: bool) -> Self {
-        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
-        req.append_header("Host", host).unwrap();
+    pub fn new(host: &str, tls: bool) -> Result<Self> {
+        let mut req = RequestHeader::build("GET", b"/", None)?;
+        req.append_header("Host", host)?;
         let sni = if tls { host.into() } else { String::new() };
-        let mut peer_template = HttpPeer::new("0.0.0.0:1", tls, sni);
+        let mut peer_template = HttpPeer::new("0.0.0.0:1", tls, sni)?;
         peer_template.options.connection_timeout = Some(Duration::from_secs(1));
         peer_template.options.read_timeout = Some(Duration::from_secs(1));
-        HttpHealthCheck {
+        Ok(HttpHealthCheck {
             consecutive_success: 1,
             consecutive_failure: 1,
             peer_template,
@@ -217,7 +217,7 @@ impl HttpHealthCheck<()> {
             port_override: None,
             health_changed_callback: None,
             backend_summary_callback: None,
-        }
+        })
     }
 }
 
@@ -233,14 +233,14 @@ where
     /// * consecutive_failure: 1
     /// * reuse_connection: false
     /// * validator: `None`, any 200 response is considered successful
-    pub fn new_custom(host: &str, tls: bool, custom: HttpConnector<C>) -> Self {
-        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
-        req.append_header("Host", host).unwrap();
+    pub fn new_custom(host: &str, tls: bool, custom: HttpConnector<C>) -> Result<Self> {
+        let mut req = RequestHeader::build("GET", b"/", None)?;
+        req.append_header("Host", host)?;
         let sni = if tls { host.into() } else { String::new() };
-        let mut peer_template = HttpPeer::new("0.0.0.0:1", tls, sni);
+        let mut peer_template = HttpPeer::new("0.0.0.0:1", tls, sni)?;
         peer_template.options.connection_timeout = Some(Duration::from_secs(1));
         peer_template.options.read_timeout = Some(Duration::from_secs(1));
-        HttpHealthCheck {
+        Ok(HttpHealthCheck {
             consecutive_success: 1,
             consecutive_failure: 1,
             peer_template,
@@ -251,7 +251,7 @@ where
             port_override: None,
             health_changed_callback: None,
             backend_summary_callback: None,
-        }
+        })
     }
 
     /// Replace the internal http connector with the given [HttpConnector]
@@ -479,7 +479,7 @@ mod test {
 
     #[tokio::test]
     async fn test_http_custom_check() {
-        let mut http_check = HttpHealthCheck::new("one.one.one.one", false);
+        let mut http_check = HttpHealthCheck::new("one.one.one.one", false).unwrap();
         http_check.validator = Some(Box::new(|resp: &ResponseHeader| {
             if resp.status == 301 {
                 Ok(())
@@ -559,7 +559,7 @@ mod test {
             };
             let bob = Box::new(ob);
 
-            let mut https_check = HttpHealthCheck::new("one.one.one.one", true);
+            let mut https_check = HttpHealthCheck::new("one.one.one.one", true).unwrap();
             https_check.health_changed_callback = Some(bob);
 
             let discovery = discovery::Static::default();

--- a/pingora-proxy/examples/backoff_retry.rs
+++ b/pingora-proxy/examples/backoff_retry.rs
@@ -66,7 +66,7 @@ impl ProxyHttp for BackoffRetryProxy {
             info!("sleeping for ms: {sleep_ms:?}");
             tokio::time::sleep(sleep_ms).await;
         }
-        let mut peer = HttpPeer::new(("10.0.0.1", 80), false, "".into());
+        let mut peer = HttpPeer::new(("10.0.0.1", 80), false, "".into())?;
         peer.options.connection_timeout = Some(Duration::from_millis(100));
         Ok(Box::new(peer))
     }

--- a/pingora-proxy/examples/ctx.rs
+++ b/pingora-proxy/examples/ctx.rs
@@ -69,7 +69,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443)
         };
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 }

--- a/pingora-proxy/examples/gateway.rs
+++ b/pingora-proxy/examples/gateway.rs
@@ -64,7 +64,7 @@ impl ProxyHttp for MyGateway {
 
         info!("connecting to {addr:?}");
 
-        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(addr, true, "one.one.one.one".to_string())?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/grpc_web_module.rs
+++ b/pingora-proxy/examples/grpc_web_module.rs
@@ -65,7 +65,7 @@ impl ProxyHttp for GrpcWebBridgeProxy {
             ("1.1.1.1", 443),
             true,
             "one.one.one.one".to_string(),
-        ));
+        )?);
         Ok(grpc_peer)
     }
 }

--- a/pingora-proxy/examples/load_balancer.rs
+++ b/pingora-proxy/examples/load_balancer.rs
@@ -39,7 +39,11 @@ impl ProxyHttp for LB {
 
         info!("upstream peer is: {:?}", upstream);
 
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(
+            upstream,
+            true,
+            "one.one.one.one".to_string(),
+        )?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/modify_response.rs
+++ b/pingora-proxy/examples/modify_response.rs
@@ -51,7 +51,7 @@ impl ProxyHttp for Json2Yaml {
         _session: &mut Session,
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
-        let peer = Box::new(HttpPeer::new(self.addr, false, HOST.to_owned()));
+        let peer = Box::new(HttpPeer::new(self.addr, false, HOST.to_owned())?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/multi_lb.rs
+++ b/pingora-proxy/examples/multi_lb.rs
@@ -48,7 +48,11 @@ impl ProxyHttp for Router {
         println!("upstream peer is: {upstream:?}");
 
         // Set SNI to one.one.one.one
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(
+            upstream,
+            true,
+            "one.one.one.one".to_string(),
+        )?);
         Ok(peer)
     }
 }

--- a/pingora-proxy/examples/pipelining.rs
+++ b/pingora-proxy/examples/pipelining.rs
@@ -42,7 +42,7 @@ impl ProxyHttp for PipelinedGateway {
         _session: &mut Session,
         _ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>> {
-        let peer = HttpPeer::new(("httpbin.org", 80), false, "httpbin.org".into());
+        let peer = HttpPeer::new(("httpbin.org", 80), false, "httpbin.org".into())?;
         Ok(Box::new(peer))
     }
 }

--- a/pingora-proxy/examples/rate_limiter.rs
+++ b/pingora-proxy/examples/rate_limiter.rs
@@ -68,7 +68,11 @@ impl ProxyHttp for LB {
     ) -> Result<Box<HttpPeer>> {
         let upstream = self.0.select(b"", 256).unwrap();
         // Set SNI
-        let peer = Box::new(HttpPeer::new(upstream, true, "one.one.one.one".to_string()));
+        let peer = Box::new(HttpPeer::new(
+            upstream,
+            true,
+            "one.one.one.one".to_string(),
+        )?);
         Ok(peer)
     }
 

--- a/pingora-proxy/examples/use_module.rs
+++ b/pingora-proxy/examples/use_module.rs
@@ -101,7 +101,7 @@ impl ProxyHttp for MyProxy {
             ("1.1.1.1", 443),
             true,
             "one.one.one.one".to_string(),
-        ));
+        )?);
         Ok(peer)
     }
 }

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -419,7 +419,7 @@ impl ProxyHttp for ExampleProxyHttp {
             format!("127.0.0.1:{port}"),
             false,
             "".to_string(),
-        ));
+        )?);
 
         if session.get_header_bytes("x-h2") == b"true" {
             // default is 1, 1
@@ -614,7 +614,7 @@ impl ProxyHttp for ExampleProxyCache {
             format!("127.0.0.1:{}", port),
             false,
             "".to_string(),
-        ));
+        )?);
 
         if session.get_header_bytes("x-h2") == b"true" {
             // default is 1, 1

--- a/pingora/examples/client.rs
+++ b/pingora/examples/client.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
 
     // create the HTTP session
     let peer_addr = "1.1.1.1:443";
-    let mut peer = HttpPeer::new(peer_addr, true, "one.one.one.one".into());
+    let mut peer = HttpPeer::new(peer_addr, true, "one.one.one.one".into()).unwrap();
     peer.options.set_http_version(2, 1);
     let (mut http, _reused) = connector.get_http_session(&peer).await?;
 


### PR DESCRIPTION
refactor: make peer/health_check safe, update proxy trait, and hide server headers

- Core/Load-Balancing: Removed panicking `unwrap()` calls in `HttpPeer` and `HttpHealthCheck` initializers. Their `new()` and `new_mtls()` functions now return `Result<Self>` instead of `Self`.
- Tests: Adjusted test suites to align with the new method signatures and modified response behavior.


Closes #921