### PR TITLE
feat: make response filters functions asynchronous in pingora

### DIFF
--- a/pingora-proxy/examples/modify_response.rs
+++ b/pingora-proxy/examples/modify_response.rs
@@ -84,7 +84,7 @@ impl ProxyHttp for Json2Yaml {
         Ok(())
     }
 
-    fn response_body_filter(
+    async fn response_body_filter(
         &self,
         _session: &mut Session,
         body: &mut Option<Bytes>,

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -403,12 +403,15 @@ where
                     .await?;
                 None
             }
-            HttpTask::Body(data, eos) | HttpTask::UpgradedBody(data, eos) => self
-                .inner
-                .upstream_response_body_filter(session, data, *eos, ctx)?,
+            HttpTask::Body(data, eos) | HttpTask::UpgradedBody(data, eos) => {
+                self.inner
+                    .upstream_response_body_filter(session, data, *eos, ctx)
+                    .await?
+            }
             HttpTask::Trailer(Some(trailers)) => {
                 self.inner
-                    .upstream_response_trailer_filter(session, trailers, ctx)?;
+                    .upstream_response_trailer_filter(session, trailers, ctx)
+                    .await?;
                 None
             }
             _ => {

--- a/pingora-proxy/src/proxy_cache.rs
+++ b/pingora-proxy/src/proxy_cache.rs
@@ -459,6 +459,7 @@ where
                         match self
                             .inner
                             .response_body_filter(session, &mut body, end, ctx)
+                            .await
                         {
                             Ok(Some(duration)) => {
                                 trace!("delaying response for {duration:?}");

--- a/pingora-proxy/src/proxy_custom.rs
+++ b/pingora-proxy/src/proxy_custom.rs
@@ -766,7 +766,8 @@ where
                 let mut data = range_body_filter.filter_body(data);
                 if let Some(duration) = self
                     .inner
-                    .response_body_filter(session, &mut data, eos, ctx)?
+                    .response_body_filter(session, &mut data, eos, ctx)
+                    .await?
                 {
                     trace!("delaying response for {duration:?}");
                     time::sleep(duration).await;
@@ -777,7 +778,8 @@ where
                 // range body filter doesn't apply to upgraded body
                 if let Some(duration) = self
                     .inner
-                    .response_body_filter(session, &mut data, eos, ctx)?
+                    .response_body_filter(session, &mut data, eos, ctx)
+                    .await?
                 {
                     trace!("delaying upgraded response for {duration:?}");
                     time::sleep(duration).await;

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -898,7 +898,8 @@ where
                 let mut data = range_body_filter.filter_body(data);
                 if let Some(duration) = self
                     .inner
-                    .response_body_filter(session, &mut data, end, ctx)?
+                    .response_body_filter(session, &mut data, end, ctx)
+                    .await?
                 {
                     trace!("delaying downstream response for {:?}", duration);
                     time::sleep(duration).await;
@@ -916,7 +917,8 @@ where
                 // range doesn't apply to upgraded body
                 if let Some(duration) = self
                     .inner
-                    .response_body_filter(session, &mut data, end, ctx)?
+                    .response_body_filter(session, &mut data, end, ctx)
+                    .await?
                 {
                     trace!("delaying downstream upgraded response for {:?}", duration);
                     time::sleep(duration).await;

--- a/pingora-proxy/src/proxy_h2.rs
+++ b/pingora-proxy/src/proxy_h2.rs
@@ -814,7 +814,8 @@ where
                 let mut data = range_body_filter.filter_body(data);
                 if let Some(duration) = self
                     .inner
-                    .response_body_filter(session, &mut data, eos, ctx)?
+                    .response_body_filter(session, &mut data, eos, ctx)
+                    .await?
                 {
                     trace!("delaying downstream response for {duration:?}");
                     time::sleep(duration).await;

--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -448,7 +448,7 @@ pub trait ProxyHttp {
     ///
     /// This function will be called every time a piece of response body is received. The `body` is
     /// **not the entire response body**.
-    fn upstream_response_body_filter(
+    async fn upstream_response_body_filter(
         &self,
         _session: &mut Session,
         _body: &mut Option<Bytes>,
@@ -459,7 +459,7 @@ pub trait ProxyHttp {
     }
 
     /// Similar to [Self::upstream_response_filter()] but for response trailers
-    fn upstream_response_trailer_filter(
+    async fn upstream_response_trailer_filter(
         &self,
         _session: &mut Session,
         _upstream_trailers: &mut header::HeaderMap,
@@ -469,7 +469,7 @@ pub trait ProxyHttp {
     }
 
     /// Similar to [Self::response_filter()] but for response body chunks
-    fn response_body_filter(
+    async fn response_body_filter(
         &self,
         _session: &mut Session,
         _body: &mut Option<Bytes>,


### PR DESCRIPTION
feat: make response filters functions asynchronous in pingora

Changed upstream_response_body_filter, upstream_response_trailer_filter, and response_body_filter to be async functions.

Closed #831