### PR TITLE
fix: don't emit the chunked terminator for zero-length body writes

### DIFF
--- a/pingora-core/src/protocols/http/v1/body.rs
+++ b/pingora-core/src/protocols/http/v1/body.rs
@@ -1383,6 +1383,15 @@ impl BodyWriter {
             BM::ChunkedEncoding(written) => {
                 let chunk_size = buf.len();
 
+                // A zero-length chunk encodes as "0\r\n\r\n", which is the
+                // chunked terminator: the peer would treat it as end of body
+                // and parse whatever follows (including the terminator that
+                // finish() writes) as the start of the next message. Skip it;
+                // finish() is the only place that ends the body.
+                if chunk_size == 0 {
+                    return Ok(Some(0));
+                }
+
                 let chuck_size_buf = format!("{:X}\r\n", chunk_size);
                 let mut output_buf = Bytes::from(chuck_size_buf).chain(buf).chain(&b"\r\n"[..]);
                 stream
@@ -1873,6 +1882,15 @@ impl BodyWriter {
         if matches!(self.send_body_state.write_state, WriteState::Idle) {
             if let Some(bytes) = self.send_body_state.pending_bytes.take() {
                 let application_bytes_size = bytes.len();
+
+                // A zero-length chunk encodes as "0\r\n\r\n", the chunked
+                // terminator: writing it here would end the body early and
+                // desync the connection (see do_write_chunked_body). Skip it;
+                // only the finish path writes the terminator.
+                if application_bytes_size == 0 {
+                    self.send_body_state.write_state = WriteState::Done(0);
+                    return Poll::Ready(Ok(Some(0)));
+                }
 
                 // Format the chunk: size\r\ndata\r\n
                 let chunk_size_header = format!("{:X}\r\n", application_bytes_size);
@@ -3295,6 +3313,70 @@ mod tests {
         let res = body_writer.finish(&mut mock_io).await.unwrap().unwrap();
         assert_eq!(res, data.len() * 2);
         assert_eq!(body_writer.body_mode, BodyMode::Complete(data.len() * 2));
+    }
+
+    #[tokio::test]
+    async fn write_body_chunked_ignores_empty_chunk() {
+        init_log();
+        let data = b"abcdefghij";
+        let output = b"A\r\nabcdefghij\r\n";
+        // The mock expects no write between the data chunk and finish():
+        // an empty chunk would encode as "0\r\n\r\n" — the terminator —
+        // ending the body early and desyncing the peer's parser.
+        let mut mock_io = Builder::new()
+            .write(&output[..])
+            .write(&LAST_CHUNK[..])
+            .build();
+        let mut body_writer = BodyWriter::new();
+        body_writer.init_chunked();
+        let res = body_writer
+            .write_body(&mut mock_io, &data[..])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(res, data.len());
+        let res = body_writer
+            .write_body(&mut mock_io, b"")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(res, 0);
+        assert_eq!(body_writer.body_mode, BodyMode::ChunkedEncoding(data.len()));
+        let res = body_writer.finish(&mut mock_io).await.unwrap().unwrap();
+        assert_eq!(res, data.len());
+        assert_eq!(body_writer.body_mode, BodyMode::Complete(data.len()));
+    }
+
+    #[tokio::test]
+    async fn write_body_task_chunked_ignores_empty_chunk() {
+        init_log();
+        let data = b"abcdefghij";
+        let output = b"A\r\nabcdefghij\r\n";
+        let mut mock_io = Builder::new()
+            .write(&output[..])
+            .write(&LAST_CHUNK[..])
+            .build();
+        let mut body_writer = BodyWriter::new();
+        body_writer.init_chunked();
+        body_writer.send_body_task(Bytes::from_static(data), None);
+        let res = body_writer
+            .write_current_body_task(&mut mock_io)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(res, data.len());
+        // an empty task must complete without emitting the terminator
+        body_writer.send_body_task(Bytes::new(), None);
+        let res = body_writer
+            .write_current_body_task(&mut mock_io)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(res, 0);
+        assert_eq!(body_writer.body_mode, BodyMode::ChunkedEncoding(data.len()));
+        let res = body_writer.finish(&mut mock_io).await.unwrap().unwrap();
+        assert_eq!(res, data.len());
+        assert_eq!(body_writer.body_mode, BodyMode::Complete(data.len()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #935.

## What

In `ChunkedEncoding` mode, `BodyWriter` encoded a zero-length application write as `0\r\n\r\n` — which on the wire *is* the chunked terminator. `finish()` then wrote the terminator again, so the peer received the end-of-body sequence twice and parsed the second one as the start of a new message, desyncing the (keep-alive) connection.

This PR makes zero-length writes a no-op in chunked mode, in both write paths:

- `do_write_chunked_body` (async path): return `Ok(Some(0))` without touching the stream.
- `poll_write_chunked_body_task` (cancel-safe task path): complete the task as `Done(0)` without writing.

`finish()` remains the only place that emits the terminator.

## Why it matters in practice

`proxy_h1.rs` forwards the final downstream body chunk to the upstream even when it is empty (the mid-stream guard is deliberately `!upstream_end_of_body && ...`). An HTTP/2 downstream that ends the request body with an empty DATA frame carrying END_STREAM — Cloudflare's *HTTP/2 to Origin* does this for streamed POST bodies, as does `curl -T -` — therefore produces `Body(Some(empty), end=true)`, and the H1 upstream receives:

```
Transfer-Encoding: chunked

11
{"hello":"world"}
0

0

```

Strict upstream parsers (e.g. uvicorn/h11) reject the duplicate terminator as a malformed pipelined request (`400 Invalid HTTP request received.`) and the poisoned pooled connection then serves that stale error to unrelated proxied requests. Full write-up with reproduction and captured wire bytes in #935.

## Tests

- `write_body_chunked_ignores_empty_chunk` — async path: data chunk, empty write (asserts no wire bytes via the mock's exact-write expectations), single terminator on `finish()`.
- `write_body_task_chunked_ignores_empty_chunk` — task path: same assertions through `send_body_task` / `write_current_body_task`.

`cargo test -p pingora-core --lib protocols::http::v1::body` passes.
