### PR TITLE
Make H2 response header reads cancellation safe

### DIFF
--- a/pingora-core/src/protocols/http/v2/client.rs
+++ b/pingora-core/src/protocols/http/v2/client.rs
@@ -179,20 +179,18 @@ impl Http2Session {
             panic!("H2 response header is already read")
         }
 
-        let Some(resp_fut) = self.resp_fut.take() else {
-            panic!("Try to take response header, but it is already taken")
+        let read_timeout = self.read_timeout;
+        let res = match read_timeout {
+            Some(t) => timeout(
+                t,
+                std::future::poll_fn(|cx| self.poll_read_response_header(cx)),
+            )
+            .await
+            .map_err(|_| Error::explain(ReadTimedout, "while reading h2 response header"))
+            .map_err(|e| self.handle_err(e))?,
+            None => std::future::poll_fn(|cx| self.poll_read_response_header(cx)).await,
         };
-
-        let res = match self.read_timeout {
-            Some(t) => timeout(t, resp_fut)
-                .await
-                .map_err(|_| Error::explain(ReadTimedout, "while reading h2 response header"))
-                .map_err(|e| self.handle_err(e))?,
-            None => resp_fut.await,
-        };
-        let (resp, body_reader) = res.map_err(handle_read_header_error)?.into_parts();
-        self.response_header = Some(resp.into());
-        self.response_body_reader = Some(body_reader);
+        res.map_err(handle_read_header_error)?;
 
         Ok(())
     }
@@ -632,6 +630,115 @@ mod tests_h2 {
     use bytes::Bytes;
     use http::{Response, StatusCode};
     use tokio::io::duplex;
+    use tokio::sync::oneshot;
+
+    async fn session_with_delayed_response() -> (
+        Http2Session,
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (client_io, server_io) = duplex(65536);
+        let (request_accepted_tx, request_accepted_rx) = oneshot::channel();
+        let (release_response_tx, release_response_rx) = oneshot::channel();
+
+        let server_task = tokio::spawn(async move {
+            let mut conn = h2::server::handshake(server_io).await.unwrap();
+            if let Some(result) = conn.accept().await {
+                let (req, mut send_resp) = result.unwrap();
+                assert_eq!(req.method(), http::Method::GET);
+                let _ = request_accepted_tx.send(());
+                let _ = release_response_rx.await;
+
+                let resp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+                send_resp.send_response(resp, true).unwrap();
+                conn.graceful_shutdown();
+            }
+            while let Some(_result) = conn.accept().await {}
+        });
+
+        let (send_req, connection) = h2::client::handshake(client_io).await.unwrap();
+        let (closed_tx, closed_rx) = tokio::sync::watch::channel(false);
+        let ping_timeout = Arc::new(AtomicBool::new(false));
+        let connection_task = tokio::spawn(async move {
+            let _ = connection.await;
+            let _ = closed_tx.send(true);
+        });
+
+        let conn_ref = crate::connectors::http::v2::ConnectionRef::new(
+            send_req.clone(),
+            closed_rx,
+            ping_timeout,
+            0,
+            1,
+            Digest::default(),
+        );
+        let mut h2s = Http2Session::new(send_req, conn_ref);
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        req.insert_header(http::header::HOST, "example.com")
+            .unwrap();
+        h2s.write_request_header(Box::new(req), true).unwrap();
+
+        request_accepted_rx
+            .await
+            .expect("server should accept the request before the response-header read");
+
+        (h2s, release_response_tx, server_task, connection_task)
+    }
+
+    #[tokio::test]
+    async fn response_header_read_can_resume_after_read_timeout() {
+        let (mut h2s, release_response, server_task, connection_task) =
+            session_with_delayed_response().await;
+        h2s.read_timeout = Some(Duration::from_millis(1));
+
+        let err = h2s
+            .read_response_header()
+            .await
+            .expect_err("delayed response header should hit the read timeout");
+        assert!(
+            matches!(err.etype, ReadTimedout),
+            "unexpected first read error: {err:?}"
+        );
+        assert!(h2s.response_header().is_none());
+        assert!(
+            h2s.resp_fut.is_some(),
+            "timing out must not drop the pending response future"
+        );
+
+        h2s.read_timeout = None;
+        release_response.send(()).unwrap();
+        h2s.read_response_header().await.unwrap();
+        assert_eq!(h2s.response_header().unwrap().status, StatusCode::OK);
+
+        server_task.abort();
+        connection_task.abort();
+    }
+
+    #[tokio::test]
+    async fn response_header_read_can_resume_after_external_cancellation() {
+        let (mut h2s, release_response, server_task, connection_task) =
+            session_with_delayed_response().await;
+
+        let first_read =
+            tokio::time::timeout(Duration::from_millis(1), h2s.read_response_header()).await;
+        assert!(
+            first_read.is_err(),
+            "external timeout should cancel the pending header read"
+        );
+        assert!(h2s.response_header().is_none());
+        assert!(
+            h2s.resp_fut.is_some(),
+            "cancelling the read must not drop the pending response future"
+        );
+
+        release_response.send(()).unwrap();
+        h2s.read_response_header().await.unwrap();
+        assert_eq!(h2s.response_header().unwrap().status, StatusCode::OK);
+
+        server_task.abort();
+        connection_task.abort();
+    }
 
     #[tokio::test]
     async fn h2_body_bytes_received_multi_frames() {


### PR DESCRIPTION
Closes #934.

## What this changes

`Http2Session::read_response_header()` now drives the existing
`poll_read_response_header()` state machine through `std::future::poll_fn`.
That poll path restores the pending `ResponseFuture` to the session before
yielding, so an internal read timeout or external future cancellation cannot
drop the only continuation while leaving the session alive.

The existing timeout error and H2 response-error mappings are unchanged.

## Tests

Added in-memory HTTP/2 regressions that:

- time out through `Http2Session::read_timeout`, then resume and read a delayed
  200 response;
- cancel the async read through an external Tokio timeout, then resume and read
  the same delayed response.

Local validation:

- `cargo test -p pingora-core --lib`
- `cargo test -p pingora-core --lib --bins --tests --no-fail-fast`
- `cargo test -p pingora-core --doc`
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy -p pingora-core --lib -- --allow=unknown-lints --deny=warnings`

The full `pingora-core` library result was 481 passed, 1 ignored, 0 failed.
