### PR TITLE
Keep an upgraded tunnel open when the request body ends after 101

### DIFF
--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -229,6 +229,12 @@ where
         let mut upstream_can_reuse = true;
         let mut send_error = None;
         let mut upgraded = false;
+        // The end of the *request body* is not the end of an upgraded tunnel. Exactly one
+        // end-of-body task belongs to the original request, but whether it is handled before
+        // or after the 101 is read is decided by task scheduling, so it has to be accounted
+        // for in both branches below. Without this the tunnel is torn down as soon as it is
+        // established whenever the upstream response wins the race.
+        let mut request_body_end_handled = false;
 
         /* duplex mode, wait for either to complete */
         while !request_done || !response_done {
@@ -242,6 +248,10 @@ where
                                 upgraded = true;
                                 if send_error.is_none() {
                                     // continue receiving from downstream after body mode change
+                                    // If the request body already ended, that end belonged to the
+                                    // request and has now been accounted for; the branch below
+                                    // must not consume a second one.
+                                    request_body_end_handled = request_done;
                                     request_done = false;
                                 }
                             }
@@ -291,12 +301,23 @@ where
                 },
 
                 body = rx.recv(), if !request_done => {
+                    // A closed pipe is the downstream half going away, which ends the tunnel
+                    // no matter what the original request body did.
+                    let downstream_pipe_closed = body.is_none();
                     match send_body_to1(client_session, body).await {
                         Ok(send_done) => {
                             request_done = send_done;
                             // An upgraded request is terminated when either side is done
                             if request_done && client_session.was_upgraded() {
-                                response_done = true;
+                                if !request_body_end_handled && !downstream_pipe_closed {
+                                    // The 101 was read while the end of the request body was
+                                    // still in the pipe. That end says the request finished,
+                                    // not that the tunnel did, so keep reading from downstream.
+                                    request_body_end_handled = true;
+                                    request_done = false;
+                                } else {
+                                    response_done = true;
+                                }
                             }
                         },
                         Err(e) => {

--- a/pingora-proxy/tests/test_upstream.rs
+++ b/pingora-proxy/tests/test_upstream.rs
@@ -1276,6 +1276,59 @@ async fn test_upgrade_body_after_101() {
 }
 
 #[tokio::test]
+async fn test_upgrade_survives_request_body_end_handled_after_101() {
+    // An upgrade request carries no body, so the downstream half queues a single
+    // end-of-body task before the upstream has answered anything. Whether that task or
+    // the 101 is handled first is decided by the scheduler: the end of the request body
+    // must not be mistaken for the end of the tunnel in either order.
+    //
+    // x-delay-request-body pins the ordering that used to tear the tunnel down the
+    // instant it was established, which otherwise only reproduces under load.
+    init();
+    let _ = *WS_ECHO_RAW;
+
+    let mut stream = TcpStream::connect("127.0.0.1:6147").await.unwrap();
+
+    let req = concat!(
+        "GET /upgrade_after_delayed_body_end HTTP/1.1\r\n",
+        "Host: 127.0.0.1\r\n",
+        "Upgrade: websocket\r\n",
+        "Connection: Upgrade\r\n",
+        "X-Port: 9284\r\n",
+        "X-Delay-Request-Body: 200\r\n",
+        "\r\n"
+    );
+    stream.write_all(req.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let fut = read_response_header(&mut stream);
+    let (resp_header, preread) = timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("timed out waiting for 101");
+    assert_eq!(resp_header.status, 101);
+
+    // The tunnel is established. It has to still be there once the delayed end of the
+    // request body lands, so send a payload and expect the origin's echo back.
+    let ws_payload = b"hello";
+    stream.write_all(ws_payload).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut echoed = preread;
+    let fut = async {
+        let mut buf = [0; 1024];
+        while echoed.len() < ws_payload.len() {
+            let n = stream.read(&mut buf).await.unwrap();
+            assert!(n > 0, "tunnel closed instead of echoing the payload back");
+            echoed.extend_from_slice(&buf[..n]);
+        }
+    };
+    timeout(Duration::from_secs(5), fut)
+        .await
+        .expect("timed out waiting for the echoed payload");
+    assert_eq!(echoed, ws_payload);
+}
+
+#[tokio::test]
 async fn test_download_timeout() {
     init();
     use tokio::time::sleep;

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -356,6 +356,18 @@ impl ProxyHttp for ExampleProxyHttp {
         {
             *body = None;
         }
+        // Test-only hook: hold the request body back so the upstream response is guaranteed
+        // to be read first. For an upgrade request the two orderings are otherwise picked by
+        // the scheduler, which makes the losing one reproducible only under load.
+        if let Some(delay) = session
+            .req_header()
+            .headers
+            .get("x-delay-request-body")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok())
+        {
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #946.

## What happens

An HTTP/1 upgrade (WebSocket) is torn down the instant it is established: the client
receives the `101`, then EOF. The client-to-upstream direction of the tunnel is never
connected, so nothing the client sends after the handshake reaches the origin.

It does not happen every time. On an idle machine it essentially never happens, which is
why it reads as a flaky test rather than a bug.

## Why

An upgrade request carries no body, so `proxy_handle_downstream` queues a single
end-of-body task into the pipe before the upstream has answered anything. In
`proxy_handle_upstream` that end is then handled while `was_upgraded()` is already true:

```rust
body = rx.recv(), if !request_done => {
    match send_body_to1(client_session, body).await {
        Ok(send_done) => {
            request_done = send_done;                          // empty body ends -> true
            // An upgraded request is terminated when either side is done
            if request_done && client_session.was_upgraded() { // 101 already read -> true
                response_done = true;                          // both true -> loop exits
            }
```

The response branch already handles the mirror-image ordering: when the 101 is read
*after* the end of the request body, it resets `request_done` so the loop keeps reading
from downstream. What is missing is that the same end-of-body task can also be handled
*after* the 101, and then nothing distinguishes "the request finished" from "the tunnel
finished".

Which order occurs is decided by task scheduling, not by anything on the wire:

- **end-of-body first** (upstream slower): `was_upgraded()` is still false, so
  `response_done` stays false; the 101 then resets `request_done` — tunnel works.
- **101 first** (upstream fast enough): `was_upgraded()` is already true when the queued
  end arrives, so both flags end up true — tunnel is dropped.

Measured in a downstream project built on pingora-proxy, forwarding WebSocket upgrades to
a local origin:

| environment | upgrades that survived |
| --- | --- |
| idle 10-core macOS host | 40/40 |
| 2-core Linux container (`docker run --cpus=2`) | 34/40 |
| same container, any delay before the origin's 101 (including a bare `yield`) | 15/15 |

The last row is what identifies the cause: inserting a yield point before the response
reorders the two tasks, and the failures disappear entirely.

## The fix

Exactly one end-of-body task belongs to the original request. Account for it once, in
whichever branch observes it first, so that only a *later* end — one that genuinely comes
from the tunnel — terminates the loop. A closed task pipe (`rx.recv()` returning `None`)
still terminates immediately, because that is the downstream half going away rather than a
request body ending.

## Test

The race cannot be pinned from the wire, but `request_body_filter` runs before the
end-of-body task is queued, so delaying it forces the failing order every time. The test
adds an `x-delay-request-body` hook to the existing test proxy — the same shape as the
`x-` hooks already there — and asserts that the tunnel still carries a payload afterwards.

It is deterministic in both directions, verified by reverting only the `proxy_h1.rs`
change and keeping the test:

```
without the fix:  panicked at 'tunnel closed instead of echoing the payload back'
with the fix:     ok
```

Full suites on `rust:1.97-bookworm` with the openresty mock origin:

```
test_upstream : 99 passed; 0 failed; 4 ignored
test_basic    : 15 passed; 0 failed
cargo fmt --all -- --check                  : clean
cargo clippy -p pingora-proxy --all-targets : no new warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
