### PR TITLE
fix: release per-key coalescing lock when RTCache writer is cancelled

### DIFF
--- a/pingora-memory-cache/src/read_through.rs
+++ b/pingora-memory-cache/src/read_through.rs
@@ -49,6 +49,34 @@ impl CacheLock {
     }
 }
 
+/// Owns the per-key lock inserted by a cache-miss writer. On drop — including
+/// when the writer future is cancelled while awaiting the user `Lookup`
+/// callback — it wakes any waiters and removes the lock entry so later
+/// same-key requests can make bounded progress instead of blocking forever on
+/// a lock whose writer is gone.
+struct WriterLockGuard {
+    lockers: Arc<RwLock<HashMap<u64, Arc<CacheLock>>>>,
+    hashed_key: u64,
+    lock: Arc<CacheLock>,
+}
+
+impl Drop for WriterLockGuard {
+    fn drop(&mut self) {
+        // Wake waiters so they can retry their own lookup. Any number of
+        // permits will do, since readers return them right away.
+        self.lock.lock.add_permits(10);
+
+        // Remove the lock only if it is still the one this guard owns: a
+        // cancelled writer must not delete a newer writer's lock.
+        let mut lockers = self.lockers.write();
+        if let Some(stored) = lockers.get(&self.hashed_key) {
+            if Arc::ptr_eq(stored, &self.lock) {
+                lockers.remove(&self.hashed_key);
+            }
+        }
+    }
+}
+
 #[async_trait]
 /// [Lookup] defines the caching behavior that the implementor needs. The `extra` field can be used
 /// to define any additional metadata that the implementor uses to determine cache eligibility.
@@ -114,7 +142,7 @@ where
 {
     inner: MemoryCache<K, T>,
     _callback: PhantomData<CB>,
-    lockers: RwLock<HashMap<u64, Arc<CacheLock>>>,
+    lockers: Arc<RwLock<HashMap<u64, Arc<CacheLock>>>>,
     lock_age: Option<Duration>,
     lock_timeout: Option<Duration>,
     phantom: PhantomData<S>,
@@ -130,7 +158,7 @@ where
     pub fn new(size: usize, lock_age: Option<Duration>, lock_timeout: Option<Duration>) -> Self {
         RTCache {
             inner: MemoryCache::new(size),
-            lockers: RwLock::new(HashMap::new()),
+            lockers: Arc::new(RwLock::new(HashMap::new())),
             _callback: PhantomData,
             lock_age,
             lock_timeout,
@@ -192,9 +220,13 @@ where
                     }
                     None => {
                         let new_lock = CacheLock::new_arc();
-                        let new_lock2 = new_lock.clone();
-                        lockers.insert(hashed_key, new_lock2);
-                        (Some(new_lock), None)
+                        let guard = WriterLockGuard {
+                            lockers: self.lockers.clone(),
+                            hashed_key,
+                            lock: new_lock.clone(),
+                        };
+                        lockers.insert(hashed_key, new_lock);
+                        (Some(guard), None)
                     }
                 } // write lock dropped
             }
@@ -267,18 +299,9 @@ where
                     (Err(err), cache_state)
                 }
             };
-            if let Some(my_write) = my_write {
-                /* add permit so that reader can start. Any number of permits will do,
-                 * since readers will return permits right away. */
-                my_write.lock.add_permits(10);
-
-                {
-                    // remove the lock from locker
-                    let mut lockers = self.lockers.write();
-                    lockers.remove(&hashed_key);
-                } // write lock dropped here
-            }
-
+            // `my_write` (the WriterLockGuard) is dropped here: it wakes
+            // waiters and removes the lock entry. If this future is cancelled
+            // while awaiting the lookup above, the same cleanup still runs.
             ret
         }
     }
@@ -738,6 +761,83 @@ mod tests {
             .multi_get([4, 5, 6].iter(), None, opt1.as_ref())
             .await
             .unwrap();
+    }
+
+    #[derive(Clone, Debug)]
+    struct CancelledLookupOpt {
+        entered: Arc<tokio::sync::Notify>,
+        used: Arc<AtomicI32>,
+    }
+
+    struct CancelledLookupCB();
+
+    #[async_trait]
+    impl Lookup<i32, i32, CancelledLookupOpt> for CancelledLookupCB {
+        async fn lookup(
+            _key: &i32,
+            extra: Option<&CancelledLookupOpt>,
+        ) -> Result<(i32, Option<Duration>), Box<dyn ErrorTrait + Send + Sync>> {
+            let extra = extra.expect("test lookup must receive coordination state");
+            let used = extra.used.fetch_add(1, atomic::Ordering::SeqCst) + 1;
+            if used == 1 {
+                extra.entered.notify_one();
+                std::future::pending::<()>().await;
+                unreachable!("first lookup is cancelled while pending");
+            }
+            Ok((used, None))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_lookup_releases_coalescing_lock() {
+        // A cache-miss writer cancelled while awaiting the user lookup
+        // callback must release the per-key coalescing lock: later same-key
+        // requests become a new writer and make progress (issue #931).
+        let cache: Arc<RTCache<i32, i32, CancelledLookupCB, CancelledLookupOpt>> =
+            Arc::new(RTCache::new(10, None, None));
+        let opt = CancelledLookupOpt {
+            entered: Arc::new(tokio::sync::Notify::new()),
+            used: Arc::new(AtomicI32::new(0)),
+        };
+        assert!(cache.lockers.read().is_empty());
+
+        let writer_cache = cache.clone();
+        let writer_opt = opt.clone();
+        let writer =
+            tokio::spawn(async move { writer_cache.get(&1, None, Some(&writer_opt)).await });
+
+        // Wait until the writer is suspended inside the lookup callback,
+        // which is the cancellation window after lock insertion.
+        opt.entered.notified().await;
+        assert_eq!(
+            opt.used.load(atomic::Ordering::SeqCst),
+            1,
+            "the first cache miss writer must enter lookup before cancellation"
+        );
+
+        writer.abort();
+        assert!(
+            writer.await.unwrap_err().is_cancelled(),
+            "aborting the writer task is the cancellation source"
+        );
+
+        let hashed_key = cache.inner.hasher.hash_one(1);
+        assert!(
+            cache.lockers.read().get(&hashed_key).is_none(),
+            "a cancelled writer must remove its coalescing lock"
+        );
+
+        // The next same-key get becomes a replacement writer and completes.
+        let (res, _status) =
+            tokio::time::timeout(Duration::from_secs(1), cache.get(&1, None, Some(&opt)))
+                .await
+                .expect("the next same-key get must make bounded progress");
+        assert_eq!(res.unwrap(), 2);
+        assert_eq!(
+            opt.used.load(atomic::Ordering::SeqCst),
+            2,
+            "the second get must become a replacement writer and call lookup again"
+        );
     }
 
     #[tokio::test]

--- a/pingora-memory-cache/src/read_through.rs
+++ b/pingora-memory-cache/src/read_through.rs
@@ -285,7 +285,11 @@ where
             /* this one will do the look up, either because it gets the write lock or the read
              * lock age is reached */
             let value = CB::lookup(key, extra).await;
-            let ret = match value {
+            // `my_write` (the WriterLockGuard) is dropped at the end of this
+            // block: it wakes waiters and removes the lock entry, and the same
+            // cleanup runs if this future is cancelled while awaiting the
+            // lookup above.
+            match value {
                 Ok((v, new_ttl)) => {
                     /* Don't put() if lock ago too old, to avoid too many concurrent writes */
                     if my_write.is_some() {
@@ -298,11 +302,7 @@ where
                     err.set_cause(e);
                     (Err(err), cache_state)
                 }
-            };
-            // `my_write` (the WriterLockGuard) is dropped here: it wakes
-            // waiters and removes the lock entry. If this future is cancelled
-            // while awaiting the lookup above, the same cleanup still runs.
-            ret
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #931

## Problem

`RTCache::get()` inserts a zero-permit `CacheLock` into `lockers` on a cache miss, then awaits the user-provided `Lookup::lookup()` callback. The lock was only released and removed after the lookup completed:

```rust
let value = CB::lookup(key, extra).await;   // cancellation point
// ... cleanup below never runs if this future is dropped
my_write.lock.add_permits(10);
lockers.remove(&hashed_key);
```

If the `get()` future is cancelled while the callback is pending (timeout, losing `select!` branch, task abort, runtime shutdown), the lock stays installed with zero permits and no live owner. Later same-key requests then:

- block forever with `lock_age = None` / `lock_timeout = None` (per-key liveness failure), or
- repeatedly bypass normal coalescing / cache insertion with `lock_timeout` / `lock_age` set.

## Fix

Introduce a `WriterLockGuard` that owns the inserted lock entry:

- On drop — including cancellation of the writer future — it wakes waiters (`add_permits`) and removes the lock from `lockers`.
- Removal is guarded by an `Arc` identity check so a cancelled old writer never deletes a newer writer's lock.
- The normal completion path now relies on the same guard's drop, so there is exactly one cleanup path.

`lockers` becomes `Arc<RwLock<...>>` so the guard can reach it without borrowing the cache.

## Tests

`test_cancelled_lookup_releases_coalescing_lock` (inverted from the issue's whitebox repro):

| Step | Verifies |
|------|----------|
| Writer enters `lookup()` then is aborted | cancellation window reachable |
| `lockers` no longer contains the key | cancelled writer removes its lock — fails without the fix |
| Next same-key `get()` completes with a fresh lookup | bounded progress; second call becomes the new writer |

Full crate suite passes (`cargo test -p pingora-memory-cache`), `cargo fmt --check` and clippy clean.
