### PR TITLE
Declare more specific arrayvec dependency

### DIFF
--- a/pingora-lru/Cargo.toml
+++ b/pingora-lru/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 hashbrown = "0"
 parking_lot = "0"
-arrayvec = "0"
+arrayvec = "0.7"
 log = { workspace = true }
 rand = "0.8"
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }


### PR DESCRIPTION
Pingora fails to compile with other versions of `arrayvec`. For example with 0.5:

```console
error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> pingora-lru/src/async_lru.rs:269:40
    |
269 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
    |                                        ^^^^^^^^    --- help: remove the unnecessary generic argument
    |                                        |
    |                                        expected 1 generic argument
    |
note: struct defined here, with 1 generic parameter: `A`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
    |
 82 | pub struct ArrayVec<A: Array> {
    |            ^^^^^^^^ -

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
    --> pingora-lru/src/async_lru.rs:278:18
     |
 278 |                 .expect("shard_lens ArrayVec filled with exactly N elements"),
     |                  ^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
     |
     = help: the following other types implement trait `arrayvec::Array`:
               [T; 0]
               [T; 1]
               [T; 2]
               [T; 3]
               [T; 4]
               [T; 5]
               [T; 6]
               [T; 7]
             and 49 others
     = note: required for `ArrayVec<[Atomic<usize>; N]>` to implement `std::fmt::Debug`
note: required by a bound in `Result::<T, E>::expect`
    --> $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:1180:12
     |
1178 |     pub fn expect(self, msg: &str) -> T
     |            ------ required by a bound in this associated function
1179 |     where
1180 |         E: fmt::Debug,
     |            ^^^^^^^^^^ required by this bound in `Result::<T, E>::expect`

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:269:30
    |
269 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:24
    |
 82 | pub struct ArrayVec<A: Array> {
    |                        ^^^^^ required by this bound in `ArrayVec`

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:269:30
    |
269 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::new`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::new`
...
117 |     pub fn new() -> ArrayVec<A> {
    |            --- required by a bound in this associated function

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:271:24
    |
271 |             shard_lens.push(AtomicUsize::new(0));
    |                        ^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::push`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::push`
...
204 |     pub fn push(&mut self, element: A::Item) {
    |            ---- required by a bound in this associated function

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:277:18
    |
277 |                 .into_inner()
    |                  ^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::into_inner`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::into_inner`
...
650 |     pub fn into_inner(self) -> Result<A, Self> {
    |            ---------- required by a bound in this associated function

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied in `ArrayVec<[Atomic<usize>; N]>`
   --> pingora-lru/src/async_lru.rs:269:13
    |
269 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
    |             ^^^^^^^^^^^^^^ within `ArrayVec<[Atomic<usize>; N]>`, the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required because it appears within the type `ArrayVec<[Atomic<usize>; N]>`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
    |
 82 | pub struct ArrayVec<A: Array> {
    |            ^^^^^^^^
    = note: all local variables must have a statically known size

error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> pingora-lru/src/async_lru.rs:420:43
    |
420 |         let mut shard_handles = arrayvec::ArrayVec::<_, N>::new();
    |                                           ^^^^^^^^    --- help: remove the unnecessary generic argument
    |                                           |
    |                                           expected 1 generic argument
    |
note: struct defined here, with 1 generic parameter: `A`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
    |
 82 | pub struct ArrayVec<A: Array> {
    |            ^^^^^^^^ -

error[E0277]: the trait bound `[ShardHandle<_>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:420:33
    |
420 |         let mut shard_handles = arrayvec::ArrayVec::<_, N>::new();
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[ShardHandle<_>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:24
    |
 82 | pub struct ArrayVec<A: Array> {
    |                        ^^^^^ required by this bound in `ArrayVec`

error[E0277]: the trait bound `[ShardHandle<_>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:420:33
    |
420 |         let mut shard_handles = arrayvec::ArrayVec::<_, N>::new();
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[ShardHandle<_>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::new`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::new`
...
117 |     pub fn new() -> ArrayVec<A> {
    |            --- required by a bound in this associated function

error[E0277]: the trait bound `[ShardHandle<_>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:433:27
    |
433 |             shard_handles.push(ShardHandle { tx: tx.clone() });
    |                           ^^^^ the trait `arrayvec::Array` is not implemented for `[ShardHandle<_>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::push`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::push`
...
204 |     pub fn push(&mut self, element: A::Item) {
    |            ---- required by a bound in this associated function

error[E0277]: the trait bound `[ShardHandle<_>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:446:37
    |
446 |             let shard_txs: Vec<_> = handles.iter().map(|h| h.tx.clone()).collect();
    |                                     ^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[ShardHandle<_>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
    = note: required for `ArrayVec<[ShardHandle<_>; N]>` to implement `Deref`

error[E0277]: the trait bound `[ShardHandle<_>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/async_lru.rs:472:18
    |
472 |                 .into_inner()
    |                  ^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[ShardHandle<_>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::into_inner`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::into_inner`
...
650 |     pub fn into_inner(self) -> Result<A, Self> {
    |            ---------- required by a bound in this associated function

error[E0277]: the trait bound `[ShardHandle<_>; N]: arrayvec::Array` is not satisfied in `ArrayVec<[ShardHandle<_>; N]>`
   --> pingora-lru/src/async_lru.rs:420:13
    |
420 |         let mut shard_handles = arrayvec::ArrayVec::<_, N>::new();
    |             ^^^^^^^^^^^^^^^^^ within `ArrayVec<[ShardHandle<_>; N]>`, the trait `arrayvec::Array` is not implemented for `[ShardHandle<_>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required because it appears within the type `ArrayVec<[ShardHandle<_>; N]>`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
    |
 82 | pub struct ArrayVec<A: Array> {
    |            ^^^^^^^^
    = note: all local variables must have a statically known size

error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
  --> pingora-lru/src/lib.rs:71:35
   |
71 |         let mut units = arrayvec::ArrayVec::<_, N>::new();
   |                                   ^^^^^^^^    --- help: remove the unnecessary generic argument
   |                                   |
   |                                   expected 1 generic argument
   |
note: struct defined here, with 1 generic parameter: `A`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
   |
82 | pub struct ArrayVec<A: Array> {
   |            ^^^^^^^^ -

error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
  --> pingora-lru/src/lib.rs:72:40
   |
72 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
   |                                        ^^^^^^^^    --- help: remove the unnecessary generic argument
   |                                        |
   |                                        expected 1 generic argument
   |
note: struct defined here, with 1 generic parameter: `A`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
   |
82 | pub struct ArrayVec<A: Array> {
   |            ^^^^^^^^ -

error[E0277]: the trait bound `[RwLock<RawRwLock, LruUnit<T>>; N]: Array` is not satisfied
  --> pingora-lru/src/lib.rs:71:25
   |
71 |         let mut units = arrayvec::ArrayVec::<_, N>::new();
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
   |
   = help: the trait `arrayvec::Array` is not implemented for `[parking_lot::lock_api::RwLock<parking_lot::RawRwLock, LruUnit<T>>; N]`
   = help: the following other types implement trait `arrayvec::Array`:
             [T; 0]
             [T; 1]
             [T; 2]
             [T; 3]
             [T; 4]
             [T; 5]
             [T; 6]
             [T; 7]
           and 49 others
note: required by a bound in `ArrayVec`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:24
   |
82 | pub struct ArrayVec<A: Array> {
   |                        ^^^^^ required by this bound in `ArrayVec`
   = note: the full name for the type has been written to '/git/tmp/pingora/target/debug/build/pingora-lru/5e8697aaef5d0470/out/pingora_lru-5e8697aaef5d0470.long-type-11277501158793496531.txt'
   = note: consider using `--verbose` to print the full type name to the console

error[E0277]: the trait bound `[RwLock<RawRwLock, LruUnit<T>>; N]: Array` is not satisfied
   --> pingora-lru/src/lib.rs:71:25
    |
 71 |         let mut units = arrayvec::ArrayVec::<_, N>::new();
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `arrayvec::Array` is not implemented for `[parking_lot::lock_api::RwLock<parking_lot::RawRwLock, LruUnit<T>>; N]`
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::new`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::new`
...
117 |     pub fn new() -> ArrayVec<A> {
    |            --- required by a bound in this associated function
    = note: the full name for the type has been written to '/git/tmp/pingora/target/debug/build/pingora-lru/5e8697aaef5d0470/out/pingora_lru-5e8697aaef5d0470.long-type-11277501158793496531.txt'
    = note: consider using `--verbose` to print the full type name to the console

error[E0277]: the trait bound `[RwLock<RawRwLock, LruUnit<T>>; N]: Array` is not satisfied
   --> pingora-lru/src/lib.rs:74:19
    |
 74 |             units.push(RwLock::new(LruUnit::with_capacity(capacity)));
    |                   ^^^^ unsatisfied trait bound
    |
    = help: the trait `arrayvec::Array` is not implemented for `[parking_lot::lock_api::RwLock<parking_lot::RawRwLock, LruUnit<T>>; N]`
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::push`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::push`
...
204 |     pub fn push(&mut self, element: A::Item) {
    |            ---- required by a bound in this associated function
    = note: the full name for the type has been written to '/git/tmp/pingora/target/debug/build/pingora-lru/5e8697aaef5d0470/out/pingora_lru-5e8697aaef5d0470.long-type-11277501158793496531.txt'
    = note: consider using `--verbose` to print the full type name to the console

error[E0277]: the trait bound `[RwLock<RawRwLock, LruUnit<T>>; N]: Array` is not satisfied
   --> pingora-lru/src/lib.rs:78:26
    |
 78 |             units: units.into_inner().map_err(|_| "").unwrap(),
    |                          ^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `arrayvec::Array` is not implemented for `[parking_lot::lock_api::RwLock<parking_lot::RawRwLock, LruUnit<T>>; N]`
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::into_inner`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::into_inner`
...
650 |     pub fn into_inner(self) -> Result<A, Self> {
    |            ---------- required by a bound in this associated function
    = note: the full name for the type has been written to '/git/tmp/pingora/target/debug/build/pingora-lru/5e8697aaef5d0470/out/pingora_lru-5e8697aaef5d0470.long-type-11277501158793496531.txt'
    = note: consider using `--verbose` to print the full type name to the console

error[E0277]: the trait bound `[RwLock<RawRwLock, LruUnit<T>>; N]: Array` is not satisfied in `ArrayVec<[RwLock<RawRwLock, LruUnit<T>>; N]>`
  --> pingora-lru/src/lib.rs:71:13
   |
71 |         let mut units = arrayvec::ArrayVec::<_, N>::new();
   |             ^^^^^^^^^ unsatisfied trait bound
   |
   = help: within `ArrayVec<[RwLock<RawRwLock, LruUnit<T>>; N]>`, the trait `arrayvec::Array` is not implemented for `[parking_lot::lock_api::RwLock<parking_lot::RawRwLock, LruUnit<T>>; N]`
   = help: the following other types implement trait `arrayvec::Array`:
             [T; 0]
             [T; 1]
             [T; 2]
             [T; 3]
             [T; 4]
             [T; 5]
             [T; 6]
             [T; 7]
           and 49 others
note: required because it appears within the type `ArrayVec<[RwLock<RawRwLock, LruUnit<T>>; N]>`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
   |
82 | pub struct ArrayVec<A: Array> {
   |            ^^^^^^^^
   = note: all local variables must have a statically known size
   = note: the full name for the type has been written to '/git/tmp/pingora/target/debug/build/pingora-lru/5e8697aaef5d0470/out/pingora_lru-5e8697aaef5d0470.long-type-14524165652267434208.txt'
   = note: consider using `--verbose` to print the full type name to the console

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
    --> pingora-lru/src/lib.rs:81:18
     |
  81 |                 .expect("shard_lens ArrayVec filled with exactly N elements"),
     |                  ^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
     |
     = help: the following other types implement trait `arrayvec::Array`:
               [T; 0]
               [T; 1]
               [T; 2]
               [T; 3]
               [T; 4]
               [T; 5]
               [T; 6]
               [T; 7]
             and 49 others
     = note: required for `ArrayVec<[Atomic<usize>; N]>` to implement `std::fmt::Debug`
note: required by a bound in `Result::<T, E>::expect`
    --> $RUSTUP_HOME/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:1180:12
     |
1178 |     pub fn expect(self, msg: &str) -> T
     |            ------ required by a bound in this associated function
1179 |     where
1180 |         E: fmt::Debug,
     |            ^^^^^^^^^^ required by this bound in `Result::<T, E>::expect`

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
  --> pingora-lru/src/lib.rs:72:30
   |
72 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
   |
   = help: the following other types implement trait `arrayvec::Array`:
             [T; 0]
             [T; 1]
             [T; 2]
             [T; 3]
             [T; 4]
             [T; 5]
             [T; 6]
             [T; 7]
           and 49 others
note: required by a bound in `ArrayVec`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:24
   |
82 | pub struct ArrayVec<A: Array> {
   |                        ^^^^^ required by this bound in `ArrayVec`

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/lib.rs:72:30
    |
 72 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::new`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::new`
...
117 |     pub fn new() -> ArrayVec<A> {
    |            --- required by a bound in this associated function

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/lib.rs:75:24
    |
 75 |             shard_lens.push(AtomicUsize::new(0));
    |                        ^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::push`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::push`
...
204 |     pub fn push(&mut self, element: A::Item) {
    |            ---- required by a bound in this associated function

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied
   --> pingora-lru/src/lib.rs:80:18
    |
 80 |                 .into_inner()
    |                  ^^^^^^^^^^ the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
    |
    = help: the following other types implement trait `arrayvec::Array`:
              [T; 0]
              [T; 1]
              [T; 2]
              [T; 3]
              [T; 4]
              [T; 5]
              [T; 6]
              [T; 7]
            and 49 others
note: required by a bound in `ArrayVec::<A>::into_inner`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:102:9
    |
102 | impl<A: Array> ArrayVec<A> {
    |         ^^^^^ required by this bound in `ArrayVec::<A>::into_inner`
...
650 |     pub fn into_inner(self) -> Result<A, Self> {
    |            ---------- required by a bound in this associated function

error[E0277]: the trait bound `[Atomic<usize>; N]: arrayvec::Array` is not satisfied in `ArrayVec<[Atomic<usize>; N]>`
  --> pingora-lru/src/lib.rs:72:13
   |
72 |         let mut shard_lens = arrayvec::ArrayVec::<_, N>::new();
   |             ^^^^^^^^^^^^^^ within `ArrayVec<[Atomic<usize>; N]>`, the trait `arrayvec::Array` is not implemented for `[Atomic<usize>; N]`
   |
   = help: the following other types implement trait `arrayvec::Array`:
             [T; 0]
             [T; 1]
             [T; 2]
             [T; 3]
             [T; 4]
             [T; 5]
             [T; 6]
             [T; 7]
           and 49 others
note: required because it appears within the type `ArrayVec<[Atomic<usize>; N]>`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/arrayvec-0.5.2/src/lib.rs:82:12
   |
82 | pub struct ArrayVec<A: Array> {
   |            ^^^^^^^^
   = note: all local variables must have a statically known size

Some errors have detailed explanations: E0107, E0277.
For more information about an error, try `rustc --explain E0107`.
error: could not compile `pingora-lru` (lib) due to 27 previous errors
```