### PR TITLE
fix: reuse the upstream connection after a response_filter error

### DIFF
--- a/pingora-proxy/src/proxy_common.rs
+++ b/pingora-proxy/src/proxy_common.rs
@@ -308,6 +308,11 @@ impl ResponseStateMachine {
 pub(crate) enum PipeState {
     Active = 0,
     DownstreamComplete = 1,
+    /// The downstream half aborted while running a response filter. The
+    /// upstream half drains the remaining response body so the connection
+    /// can still be reused (e.g. a 3xx redirect followed by the outer retry
+    /// loop after a `response_filter` error).
+    DownstreamFilterAborted = 2,
 }
 
 impl PipeState {
@@ -316,6 +321,11 @@ impl PipeState {
     /// comparison the upstream halves perform on a task-pipe closure.
     pub(crate) fn is_downstream_complete(raw: u8) -> bool {
         raw == PipeState::DownstreamComplete as u8
+    }
+
+    /// Whether `raw` is [`DownstreamFilterAborted`](Self::DownstreamFilterAborted).
+    pub(crate) fn is_downstream_filter_aborted(raw: u8) -> bool {
+        raw == PipeState::DownstreamFilterAborted as u8
     }
 }
 

--- a/pingora-proxy/src/proxy_h1.rs
+++ b/pingora-proxy/src/proxy_h1.rs
@@ -121,18 +121,73 @@ where
         let pipe_state = Arc::new(AtomicU8::new(PipeState::Active as u8));
 
         // start bi-directional streaming
-        let ret = tokio::try_join!(
-            self.proxy_handle_downstream(
-                session,
-                tx_downstream,
-                rx_upstream,
-                ctx,
-                &mut downstream_custom_message_writer,
-                &mut downstream_custom_message_reader,
-                pipe_state.clone(),
-            ),
-            self.proxy_handle_upstream(client_session, tx_upstream, rx_downstream, pipe_state),
-        );
+        // Unlike try_join!, an error from the downstream half does not cancel
+        // the upstream half: when the downstream half aborted in a response
+        // filter, the upstream half is allowed to drain the remaining
+        // response body so the connection can still be reused (issue #866).
+        let mut downstream = Box::pin(self.proxy_handle_downstream(
+            session,
+            tx_downstream,
+            rx_upstream,
+            ctx,
+            &mut downstream_custom_message_writer,
+            &mut downstream_custom_message_reader,
+            pipe_state.clone(),
+        ));
+        let mut upstream = Box::pin(self.proxy_handle_upstream(
+            client_session,
+            tx_upstream,
+            rx_downstream,
+            pipe_state.clone(),
+        ));
+
+        let (downstream_can_reuse, upstream_can_reuse, error) = tokio::select! {
+            r = &mut downstream => {
+                match r {
+                    Ok(downstream_can_reuse) => {
+                        match (&mut upstream).await {
+                            Ok(upstream_can_reuse) => (downstream_can_reuse, upstream_can_reuse, None),
+                            Err(e) => (false, false, Some(e)),
+                        }
+                    }
+                    Err(e) => {
+                        if PipeState::is_downstream_filter_aborted(
+                            pipe_state.load(Ordering::Acquire),
+                        ) {
+                            // The downstream half aborted in a response filter
+                            // (e.g. a 3xx redirect followed by the outer retry
+                            // loop). Let the upstream half drain the remaining
+                            // response body; the connection is reusable only if
+                            // the drain completed.
+                            match (&mut upstream).await {
+                                Ok(true) => (false, true, Some(e)),
+                                Ok(false) => (false, false, Some(e)),
+                                Err(up_e) => (false, false, Some(up_e)),
+                            }
+                        } else {
+                            // Fail fast, dropping the upstream half; the caller
+                            // closes the connection since client_reuse=false.
+                            (false, false, Some(e))
+                        }
+                    }
+                }
+            }
+            r = &mut upstream => {
+                match r {
+                    Ok(upstream_can_reuse) => {
+                        match (&mut downstream).await {
+                            Ok(downstream_can_reuse) => (downstream_can_reuse, upstream_can_reuse, None),
+                            Err(e) => (false, false, Some(e)),
+                        }
+                    }
+                    Err(e) => (false, false, Some(e)),
+                }
+            }
+        };
+        // Release the borrows held by the two halves before restoring the
+        // custom message handles below.
+        drop(downstream);
+        drop(upstream);
 
         if let Some(custom_session) = session.downstream_session.as_custom_mut() {
             if let Some(downstream_custom_message_writer) = downstream_custom_message_writer {
@@ -155,12 +210,7 @@ where
             }
         }
 
-        match ret {
-            Ok((downstream_can_reuse, upstream_can_reuse)) => {
-                (downstream_can_reuse, upstream_can_reuse, None)
-            }
-            Err(e) => (false, false, Some(e)),
-        }
+        (downstream_can_reuse, upstream_can_reuse, error)
     }
 
     pub(crate) async fn proxy_to_h1_upstream(
@@ -275,6 +325,15 @@ where
                                     // unread bytes and is unsafe to reuse.
                                     return Ok(false);
                                 }
+                                if PipeState::is_downstream_filter_aborted(
+                                    pipe_state.load(Ordering::Acquire),
+                                ) {
+                                    // The downstream half aborted in a response filter
+                                    // (e.g. a 3xx redirect followed by the outer retry
+                                    // loop). Drain the remaining upstream response so the
+                                    // connection can be returned to the pool (issue #866).
+                                    return self.drain_upstream_response(client_session).await;
+                                }
                                 // The pipe closed but the downstream half did not signal completion:
                                 // this is an unexpected closure, so surface the original send error.
                                 return Err(result.expect_err("send failure already checked via is_err() above"));
@@ -326,6 +385,48 @@ where
         Ok(upstream_can_reuse)
     }
 
+    /// Maximum number of bytes drained from an upstream response after the
+    /// downstream half aborted in a response filter. Larger responses abandon
+    /// the connection instead of being reused, bounding the drain cost.
+    const MAX_RESPONSE_DRAIN_BYTES: usize = 1024 * 1024;
+
+    /// Drains the remaining upstream response body after the downstream half
+    /// aborted in a response filter, so the connection can be reused. Returns
+    /// true when the response was fully consumed within the drain bound.
+    async fn drain_upstream_response(&self, client_session: &mut HttpSessionV1) -> Result<bool> {
+        if client_session.was_upgraded() {
+            // Upgraded bodies have no framing to drain; never reuse.
+            return Ok(false);
+        }
+        let mut drained = 0usize;
+        loop {
+            match client_session.read_response_task().await {
+                Ok(task) => {
+                    if task.is_end() {
+                        return Ok(true);
+                    }
+                    let data_len = match &task {
+                        HttpTask::Body(data, _) | HttpTask::UpgradedBody(data, _) => {
+                            data.as_ref().map_or(0, |d| d.len())
+                        }
+                        _ => 0,
+                    };
+                    drained += data_len;
+                    if drained > Self::MAX_RESPONSE_DRAIN_BYTES {
+                        warn!(
+                            "upstream response exceeds drain bound after filter abort; not reusing connection"
+                        );
+                        return Ok(false);
+                    }
+                }
+                Err(e) => {
+                    warn!("failed to drain upstream response after filter abort: {e}");
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn process_upstream_tasks(
         &self,
@@ -336,6 +437,7 @@ where
         serve_from_cache: &mut ServeFromCache,
         range_body_filter: &mut proxy_cache::range_filter::RangeBodyFilter,
         response_state: &mut ResponseStateMachine,
+        pipe_state: &AtomicU8,
     ) -> Result<Option<bool>>
     where
         SV: ProxyHttp + Send + Sync,
@@ -379,9 +481,20 @@ where
             #[cfg(feature = "upstream_modules")]
             session.upstream_modules_filter_task(&mut t).await?;
             session.upstream_compression.response_filter(&mut t);
-            let task = self
+            let task = match self
                 .h1_response_filter(session, t, ctx, serve_from_cache, range_body_filter, false)
-                .await?;
+                .await
+            {
+                Ok(t) => t,
+                Err(e) => {
+                    // A response_filter error (e.g. a 3xx redirect followed by
+                    // the outer retry loop) aborts the downstream half. Signal
+                    // the upstream half to drain the remaining response body so
+                    // the connection can still be reused (issue #866).
+                    pipe_state.store(PipeState::DownstreamFilterAborted as u8, Ordering::Release);
+                    return Err(e);
+                }
+            };
             if serve_from_cache.is_miss_header() {
                 response_state.enable_cached_response();
             }
@@ -595,6 +708,7 @@ where
                             &mut serve_from_cache,
                             &mut range_body_filter,
                             &mut response_state,
+                            &pipe_state,
                         ).await? else {
                             // nothing sent downstream e.g. serve_from_cache
                             continue;
@@ -620,6 +734,7 @@ where
                             &mut serve_from_cache,
                             &mut range_body_filter,
                             &mut response_state,
+                            &pipe_state,
                         ).await? else {
                             // nothing sent downstream e.g. serve_from_cache
                             continue;

--- a/pingora-proxy/tests/test_redirect_conn_reuse.rs
+++ b/pingora-proxy/tests/test_redirect_conn_reuse.rs
@@ -1,0 +1,225 @@
+// Copyright 2026 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for issue #866: when `response_filter` returns an error
+//! (e.g. a 3xx redirect followed by the outer retry loop), the remaining
+//! upstream response body must be drained so the connection is returned to
+//! the pool instead of being dropped. A later request to the same origin
+//! must reuse the drained connection.
+
+use async_trait::async_trait;
+use pingora_core::server::configuration::Opt;
+use pingora_core::server::Server;
+use pingora_core::services::ServiceWithDependents;
+use pingora_core::upstreams::peer::HttpPeer;
+use pingora_error::{Error, Result};
+use pingora_http::ResponseHeader;
+use pingora_proxy::{http_proxy_service, ProxyHttp, Session};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const PROXY_PORT: u16 = 6155;
+
+/// Minimal HTTP/1.1 origin. Serves `GET /a` with a 302 + body split across
+/// two writes (so the upstream half is still reading when the downstream
+/// half aborts), and any other path with a 200. Reads requests on the same
+/// connection until EOF.
+async fn handle_origin_conn(mut sock: TcpStream) {
+    loop {
+        let mut head = Vec::new();
+        let mut buf = [0u8; 512];
+        loop {
+            match sock.read(&mut buf).await {
+                Ok(0) => return,
+                Ok(n) => {
+                    head.extend_from_slice(&buf[..n]);
+                    if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+        let head_str = String::from_utf8_lossy(&head);
+        if head_str.starts_with("GET /a") {
+            // Split the body across two writes with a delay so the upstream
+            // half is still reading when the downstream half aborts in
+            // response_filter — the drain path (issue #866) is what makes
+            // the connection reusable in that window.
+            sock.write_all(
+                b"HTTP/1.1 302 Found\r\nLocation: /b\r\nContent-Length: 12\r\n\r\nredir",
+            )
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            sock.write_all(b"ecting\n").await.unwrap();
+        } else {
+            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nok\n")
+                .await
+                .unwrap();
+        }
+    }
+}
+
+/// Starts an origin and returns its port. Counts accepted TCP connections.
+async fn run_origin(accepts: Arc<AtomicUsize>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((sock, _)) = listener.accept().await {
+            accepts.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(handle_origin_conn(sock));
+        }
+    });
+    port
+}
+
+/// Follows a 3xx redirect by rewriting the request URI and erroring out of
+/// `response_filter` with retry enabled, relying on the outer retry loop.
+/// The redirect target is served by a different origin so the retry is
+/// guaranteed to open a new connection, leaving the drained connection in
+/// the first origin's pool.
+struct RedirectFollowProxy {
+    origin_a: u16,
+    origin_b: u16,
+}
+
+#[async_trait]
+impl ProxyHttp for RedirectFollowProxy {
+    type CTX = ();
+
+    fn new_ctx(&self) -> Self::CTX {}
+
+    async fn upstream_peer(&self, session: &mut Session, _ctx: &mut ()) -> Result<Box<HttpPeer>> {
+        let port = if session.req_header().uri.path() == "/b" {
+            self.origin_b
+        } else {
+            self.origin_a
+        };
+        Ok(Box::new(HttpPeer::new(
+            format!("127.0.0.1:{port}"),
+            false,
+            String::new(),
+        )))
+    }
+
+    async fn response_filter(
+        &self,
+        session: &mut Session,
+        resp: &mut ResponseHeader,
+        _ctx: &mut (),
+    ) -> Result<()> {
+        if resp.status == http::StatusCode::FOUND {
+            if let Some(location) = resp.headers.get("location").and_then(|v| v.to_str().ok()) {
+                if let Ok(uri) = location.parse::<http::Uri>() {
+                    session.as_downstream_mut().req_header_mut().set_uri(uri);
+                }
+            }
+            let mut e = Error::new_str("redirect follow");
+            e.set_retry(true);
+            return Err(e);
+        }
+        Ok(())
+    }
+}
+
+fn start_proxy(origin_a: u16, origin_b: u16) {
+    // Minimal conf: the shared test conf binds upstream client sockets to
+    // 127.0.0.2, which is not portable to all platforms.
+    std::fs::write("/tmp/pingora_redirect_reuse.yaml", "---\nversion: 1\n").unwrap();
+    let opts = vec![
+        "pingora-proxy".to_string(),
+        "-c".to_string(),
+        "/tmp/pingora_redirect_reuse.yaml".to_string(),
+    ];
+    let mut server = Server::new(Some(Opt::parse_from_args(opts))).unwrap();
+    server.bootstrap();
+    let conf = server.configuration.clone();
+    let mut proxy = http_proxy_service(&conf, RedirectFollowProxy { origin_a, origin_b });
+    proxy.add_tcp(&format!("0.0.0.0:{PROXY_PORT}"));
+    let services: Vec<Box<dyn ServiceWithDependents>> = vec![Box::new(proxy)];
+    server.add_services(services);
+    thread::spawn(move || server.run_forever());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redirect_filter_error_reuses_upstream_connection() {
+    let accepts_a = Arc::new(AtomicUsize::new(0));
+    let accepts_b = Arc::new(AtomicUsize::new(0));
+    let origin_a = run_origin(accepts_a.clone()).await;
+    let origin_b = run_origin(accepts_b.clone()).await;
+    start_proxy(origin_a, origin_b);
+
+    let client = reqwest::Client::new();
+
+    // Wait for the proxy to come up.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if client
+            .get(format!("http://127.0.0.1:{PROXY_PORT}/probe"))
+            .send()
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("proxy did not come up in time");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Redirect flow: /a -> 302 -> response_filter error -> outer retry ->
+    // /b on the other origin. The /a connection has an unfinished response
+    // body at abort time; the drain must return it to origin A's pool.
+    let res = client
+        .get(format!("http://127.0.0.1:{PROXY_PORT}/a"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), http::StatusCode::OK);
+    assert_eq!(res.text().await.unwrap(), "ok\n");
+
+    // Wait for origin A's delayed body to arrive and the drain to finish.
+    tokio::time::sleep(Duration::from_millis(700)).await;
+
+    // A later request to origin A must reuse the drained connection: no new
+    // accept. Without the drain (issue #866), the aborted connection is
+    // dropped and this request opens a new one.
+    let res = client
+        .get(format!("http://127.0.0.1:{PROXY_PORT}/c"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), http::StatusCode::OK);
+    assert_eq!(res.text().await.unwrap(), "ok\n");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Origin A: a single connection serves the probe, /a (reusing it), and
+    // the follow-up /c — the drained connection must be reused instead of
+    // opening a new one. Without the drain (issue #866), the aborted
+    // connection is dropped and /c opens a second connection.
+    assert_eq!(
+        accepts_a.load(Ordering::SeqCst),
+        1,
+        "the drained connection must be reused by a later request"
+    );
+    // Origin B: only the redirect retry.
+    assert_eq!(accepts_b.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary

Fixes #866

## Problem

When user code follows a 3xx redirect by returning `Err` from `ProxyHttp::response_filter` (with `retry = true`) and relies on the outer `process_request` retry loop, the upstream **keep-alive connection is never returned to the pool** — every retry and later request opens a new upstream connection.

**Root cause:** `proxy_1to1` used `tokio::try_join!`, which **cancels the upstream half** the moment the downstream half errors. The remaining upstream response body (e.g. the 3xx body) was never consumed, so the connection was dropped instead of released.

## Fix

1. New `PipeState::DownstreamFilterAborted`: the downstream half signals it when `h1_response_filter` fails.
2. `proxy_1to1` now uses a select-based join instead of `try_join!`:
   - When the downstream half aborts in a response filter, the upstream half is polled to completion and **drains the remaining response body** (bounded by a 1 MiB cap plus the peer read timeout), then the connection is released to the pool for reuse.
   - All other error paths keep the previous fail-fast behavior (the sibling future is dropped immediately).
3. The upstream half returns `Ok(true)` (reusable) only when the drain fully consumed the response; `Ok(false)` otherwise.

## Tests

New self-contained `tests/test_redirect_conn_reuse.rs` (in-process proxy + two scripted TCP origins, no nginx):

| Step | Verifies |
|------|----------|
| `GET /a` → 302 with a **delayed split body** (upstream half is still reading when the downstream half aborts) | abort happens mid-response |
| `response_filter` errors with retry → outer retry serves `/b` from origin B | retry still works |
| Later `GET /c` to origin A | **reuses the drained connection** — origin A sees exactly 1 accept; without the fix it sees 2 (fails) |

Lib tests pass (22), `cargo fmt --check` and clippy clean for the touched files.
