### PR TITLE
limits: add peek and proportional_rate methods to Rate

### DIFF
--- a/pingora-limits/src/rate.rs
+++ b/pingora-limits/src/rate.rs
@@ -139,6 +139,21 @@ impl Rate {
         self.current(self.red_or_blue()).incr(key, events)
     }
 
+    /// Return the estimated number of events observed in the current interval without modifying the counter.
+    pub fn peek<T: Hash>(&self, key: &T) -> isize {
+        let past_ms = self.maybe_reset();
+        if past_ms >= self.reset_interval_ms * 2 {
+            return 0;
+        }
+        self.current(self.red_or_blue()).get(key)
+    }
+
+    /// Return the proportional rate estimation per second over the sliding interval using
+    /// [`PROPORTIONAL_RATE_ESTIMATE_CALC_FN`].
+    pub fn proportional_rate<T: Hash>(&self, key: &T) -> f64 {
+        self.rate_with(key, PROPORTIONAL_RATE_ESTIMATE_CALC_FN)
+    }
+
     // reset if needed, return the time since last reset for other fn to use
     fn maybe_reset(&self) -> u64 {
         // should be short enough not to overflow
@@ -343,5 +358,22 @@ mod tests {
         // second: 3
         sleep(Duration::from_secs(1));
         assert_eq!(r.rate_with(&key, PROPORTIONAL_RATE_ESTIMATE_CALC_FN), 0f64);
+    }
+
+    #[test]
+    fn test_peek_and_proportional_rate() {
+        let r = Rate::new(Duration::from_secs(1));
+        let key = "client_ip_1";
+
+        assert_eq!(r.peek(&key), 0);
+        assert_eq_ish(r.proportional_rate(&key), 0.);
+
+        r.observe(&key, 5);
+        assert_eq!(r.peek(&key), 5);
+        assert_eq_ish(r.proportional_rate(&key), 5.);
+
+        r.observe(&key, 3);
+        assert_eq!(r.peek(&key), 8);
+        assert_eq_ish(r.proportional_rate(&key), 8.);
     }
 }


### PR DESCRIPTION
### Summary
Adds non-mutating rate inspection methods (`peek` and `proportional_rate`) to `pingora_limits::rate::Rate`.

### Motivation & Problem
When building WAF proxies, traffic inspectors, and multi-stage rate-limiting middleware using `pingora-limits`, callers frequently need to **inspect / dry-run** current event counts or sliding window rates for IP reputation scoring and logging *without* incrementing the rate counter via `observe()`.

Previously, callers had no way to non-destructively peek into the current interval event count, and using `PROPORTIONAL_RATE_ESTIMATE_CALC_FN` required manually passing the closure to `rate_with(...)` on every call.

### Key Changes
* **`Rate::peek`**: Non-mutating method returning estimated number of events observed in the current interval.
* **`Rate::proportional_rate`**: Ergonomic helper method returning real-time per-second rate estimation calculated over the sliding interval via `PROPORTIONAL_RATE_ESTIMATE_CALC_FN`.
* **Unit Tests**: Added `test_peek_and_proportional_rate` in `pingora-limits/src/rate.rs`.

### Verification
- `cargo test -p pingora-limits`: Passed 9/9 unit tests cleanly.
- `Signed-off-by`: Yes.