### PR TITLE
Replace once_cell with standard library primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ http = "1"
 log = "0.4"
 futures = "0.3"
 h2 = ">=0.4.14"
-once_cell = "1"
 lru = "0.16.3"
 ahash = ">=0.8.9"
 

--- a/docs/user_guide/prom.md
+++ b/docs/user_guide/prom.md
@@ -24,7 +24,9 @@ pingora-prometheus = "0.8.0"
 The simplest way to use it is to have [static metrics](https://docs.rs/prometheus/latest/prometheus/#static-metrics).
 
 ```rust
-static MY_COUNTER: Lazy<IntGauge> = Lazy::new(|| {
+use std::sync::LazyLock;
+
+static MY_COUNTER: LazyLock<IntGauge> = LazyLock::new(|| {
     register_int_gauge!("my_counter", "my counter").unwrap()
 });
 

--- a/docs/user_guide/rate_limiter.md
+++ b/docs/user_guide/rate_limiter.md
@@ -7,7 +7,6 @@ Pingora provides a crate `pingora-limits` which provides a simple and easy to us
    async-trait="0.1"
    pingora = { version = "0.8", features = [ "lb", "openssl" ] }
    pingora-limits = "0.8.0"
-   once_cell = "1.19.0"
    ```
 2. Declare a global rate limiter map to store the rate limiter for each client. In this example, we use `appid`.
 3. Override the `request_filter` method in the `ProxyHttp` trait to implement rate limiting.
@@ -19,11 +18,10 @@ Pingora provides a crate `pingora-limits` which provides a simple and easy to us
 ## Example
 ```rust
 use async_trait::async_trait;
-use once_cell::sync::Lazy;
 use pingora::http::ResponseHeader;
 use pingora::prelude::*;
 use pingora_limits::rate::Rate;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 fn main() {
@@ -67,7 +65,7 @@ impl LB {
 }
 
 // Rate limiter
-static RATE_LIMITER: Lazy<Rate> = Lazy::new(|| Rate::new(Duration::from_secs(1)));
+static RATE_LIMITER: LazyLock<Rate> = LazyLock::new(|| Rate::new(Duration::from_secs(1)));
 
 // max request per second per client
 static MAX_REQ_PER_SEC: isize = 1;

--- a/pingora-cache/Cargo.toml
+++ b/pingora-cache/Cargo.toml
@@ -27,7 +27,6 @@ pingora-timeout = { version = "0.8.0", path = "../pingora-timeout" }
 bstr = { workspace = true }
 http = { workspace = true }
 indexmap = "1"
-once_cell = { workspace = true }
 regex = "1"
 blake2 = "0.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/pingora-cache/src/cache_control.rs
+++ b/pingora-cache/src/cache_control.rs
@@ -19,13 +19,13 @@ use super::*;
 use http::header::HeaderName;
 use http::HeaderValue;
 use indexmap::IndexMap;
-use once_cell::sync::Lazy;
 use pingora_error::{Error, ErrorType};
 use regex::bytes::Regex;
 use std::fmt;
 use std::num::IntErrorKind;
 use std::slice;
 use std::str;
+use std::sync::LazyLock;
 
 /// The max delta-second per [RFC 9111](https://datatracker.ietf.org/doc/html/rfc9111#section-1.2.2)
 // "If a cache receives a delta-seconds value
@@ -352,13 +352,13 @@ impl<'a> Iterator for ListValueIter<'a> {
 // note the `token` implementation excludes disallowed ASCII ranges
 // and disallowed delimiters: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2
 // though it does not forbid `obs-text`: %x80-FF
-static RE_CACHE_DIRECTIVE: Lazy<Regex> =
+static RE_CACHE_DIRECTIVE: LazyLock<Regex> =
     // to break our version down further:
     // `(?-u)`: unicode support disabled, which puts the regex into "ASCII compatible mode" for specifying literal bytes like \x7F: https://docs.rs/regex/1.10.4/regex/bytes/index.html#syntax
     // `(?:^|(?:\s*[,;]\s*)`: allow either , or ; as a delimiter
     // `([^\x00-\x20\(\)<>@,;:\\"/\[\]\?=\{\}\x7F]+)`: token (directive name capture group)
     // `(?:=((?:[^\x00-\x20\(\)<>@,;:\\"/\[\]\?=\{\}\x7F]+|(?:"(?:[^"\\]|\\.)*"))))`: token OR quoted-string (directive value capture-group)
-    Lazy::new(|| {
+    LazyLock::new(|| {
         Regex::new(r#"(?-u)(?:^|(?:\s*[,;]\s*))([^\x00-\x20\(\)<>@,;:\\"/\[\]\?=\{\}\x7F]+)(?:=((?:[^\x00-\x20\(\)<>@,;:\\"/\[\]\?=\{\}\x7F]+|(?:"(?:[^"\\]|\\.)*"))))?"#).unwrap()
     });
 

--- a/pingora-cache/src/memory.rs
+++ b/pingora-cache/src/memory.rs
@@ -427,7 +427,7 @@ impl Storage for MemCache {
 mod test {
     use super::*;
     use crate::trace::Span;
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     fn gen_meta() -> CacheMeta {
         let mut header = ResponseHeader::build(200, None).unwrap();
@@ -445,7 +445,7 @@ mod test {
 
     #[tokio::test]
     async fn test_write_then_read() {
-        static MEM_CACHE: Lazy<MemCache> = Lazy::new(MemCache::new);
+        static MEM_CACHE: LazyLock<MemCache> = LazyLock::new(MemCache::new);
         let span = &Span::inactive().handle();
 
         let key1 = CacheKey::new("a", "1");
@@ -482,7 +482,7 @@ mod test {
 
     #[tokio::test]
     async fn test_read_range() {
-        static MEM_CACHE: Lazy<MemCache> = Lazy::new(MemCache::new);
+        static MEM_CACHE: LazyLock<MemCache> = LazyLock::new(MemCache::new);
         let span = &Span::inactive().handle();
 
         let key1 = CacheKey::new("a", "1");
@@ -527,7 +527,7 @@ mod test {
     async fn test_write_while_read() {
         use futures::FutureExt;
 
-        static MEM_CACHE: Lazy<MemCache> = Lazy::new(MemCache::new);
+        static MEM_CACHE: LazyLock<MemCache> = LazyLock::new(MemCache::new);
         let span = &Span::inactive().handle();
 
         let key1 = CacheKey::new("a", "1");
@@ -594,7 +594,7 @@ mod test {
 
     #[tokio::test]
     async fn test_purge_partial() {
-        static MEM_CACHE: Lazy<MemCache> = Lazy::new(MemCache::new);
+        static MEM_CACHE: LazyLock<MemCache> = LazyLock::new(MemCache::new);
         let cache = &MEM_CACHE;
 
         let key = CacheKey::new("a", "1").to_compact();
@@ -621,7 +621,7 @@ mod test {
 
     #[tokio::test]
     async fn test_purge_complete() {
-        static MEM_CACHE: Lazy<MemCache> = Lazy::new(MemCache::new);
+        static MEM_CACHE: LazyLock<MemCache> = LazyLock::new(MemCache::new);
         let cache = &MEM_CACHE;
 
         let key = CacheKey::new("a", "1").to_compact();

--- a/pingora-cache/src/meta.rs
+++ b/pingora-cache/src/meta.rs
@@ -16,12 +16,12 @@
 
 pub use http::Extensions;
 use log::warn;
-use once_cell::sync::{Lazy, OnceCell};
 use pingora_error::{Error, ErrorType::*, OrErr, Result};
 use pingora_header_serde::HeaderSerde;
 use pingora_http::{HMap, ResponseHeader};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::sync::{LazyLock, OnceLock};
 use std::time::{Duration, SystemTime};
 
 use crate::key::HashBinary;
@@ -939,9 +939,9 @@ impl CacheMetaDefaults {
 /// The dictionary content for header compression.
 ///
 /// Used during initialization of [`HEADER_SERDE`].
-static COMPRESSION_DICT_CONTENT: OnceCell<Cow<'static, [u8]>> = OnceCell::new();
+static COMPRESSION_DICT_CONTENT: OnceLock<Cow<'static, [u8]>> = OnceLock::new();
 
-static HEADER_SERDE: Lazy<HeaderSerde> = Lazy::new(|| {
+static HEADER_SERDE: LazyLock<HeaderSerde> = LazyLock::new(|| {
     let dict_opt = if let Some(dict_content) = COMPRESSION_DICT_CONTENT.get() {
         Some(dict_content.to_vec())
     } else {

--- a/pingora-cache/src/put.rs
+++ b/pingora-cache/src/put.rs
@@ -241,7 +241,7 @@ impl<C: CachePut> CachePutCtx<C> {
 mod test {
     use super::*;
     use crate::trace::Span;
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     struct TestCachePut();
     impl CachePut for TestCachePut {
@@ -253,7 +253,7 @@ mod test {
     }
 
     type TestCachePutCtx = CachePutCtx<TestCachePut>;
-    static CACHE_BACKEND: Lazy<MemCache> = Lazy::new(MemCache::new);
+    static CACHE_BACKEND: LazyLock<MemCache> = LazyLock::new(MemCache::new);
 
     #[tokio::test]
     async fn test_cache_put() {

--- a/pingora-core/Cargo.toml
+++ b/pingora-core/Cargo.toml
@@ -40,7 +40,6 @@ log = { workspace = true }
 h2 = { workspace = true }
 derivative.workspace = true
 clap = { version = "4.5", features = ["derive"] }
-once_cell = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 strum = "0.26.2"

--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -237,12 +237,12 @@ where
     digest
         .peer_addr
         .set(Some(peer_addr.clone()))
-        .expect("newly created OnceCell must be empty");
+        .expect("newly created OnceLock must be empty");
     if let Some(local_addr) = local_addr {
         digest
             .local_addr
             .set(Some(SocketAddr::Inet(local_addr)))
-            .expect("newly created OnceCell must be empty");
+            .expect("newly created OnceLock must be empty");
     }
     stream.set_socket_digest(digest);
 

--- a/pingora-core/src/modules/http/mod.rs
+++ b/pingora-core/src/modules/http/mod.rs
@@ -26,13 +26,13 @@ pub mod grpc_web;
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::HeaderMap;
-use once_cell::sync::OnceCell;
 use pingora_error::Result;
 use pingora_http::{RequestHeader, ResponseHeader};
 use std::any::Any;
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 /// The trait an HTTP traffic module needs to implement
 #[async_trait]
@@ -101,7 +101,7 @@ pub type ModuleBuilder = Box<dyn HttpModuleBuilder + 'static + Send + Sync>;
 /// The object to hold multiple http modules
 pub struct HttpModules {
     modules: Vec<ModuleBuilder>,
-    module_index: OnceCell<Arc<HashMap<TypeId, usize>>>,
+    module_index: OnceLock<Arc<HashMap<TypeId, usize>>>,
 }
 
 impl HttpModules {
@@ -109,7 +109,7 @@ impl HttpModules {
     pub fn new() -> Self {
         HttpModules {
             modules: vec![],
-            module_index: OnceCell::new(),
+            module_index: OnceLock::new(),
         }
     }
 

--- a/pingora-core/src/offload.rs
+++ b/pingora-core/src/offload.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use log::debug;
-use once_cell::sync::OnceCell;
 use rand::Rng;
+use std::sync::OnceLock;
 use tokio::runtime::{Builder, Handle};
 use tokio::sync::oneshot::{channel, Sender};
 
@@ -31,7 +31,7 @@ pub(crate) struct OffloadRuntime {
     thread_per_shard: usize,
     // Lazily init the runtimes so that they are created after pingora
     // daemonize itself. Otherwise the runtime threads are lost.
-    pools: OnceCell<Box<[(Handle, Sender<()>)]>>,
+    pools: OnceLock<Box<[(Handle, Sender<()>)]>>,
 }
 
 impl OffloadRuntime {
@@ -54,7 +54,7 @@ impl OffloadRuntime {
             thread_name,
             shards,
             thread_per_shard,
-            pools: OnceCell::new(),
+            pools: OnceLock::new(),
         }
     }
 

--- a/pingora-core/src/protocols/digest.rs
+++ b/pingora-core/src/protocols/digest.rs
@@ -14,10 +14,8 @@
 
 //! Extra information about the connection
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, SystemTime};
-
-use once_cell::sync::OnceCell;
 
 use super::l4::ext::{get_original_dest, get_recv_buf, get_snd_buf, get_tcp_info, TCP_INFO};
 use super::l4::socket::SocketAddr;
@@ -83,11 +81,11 @@ pub struct SocketDigest {
     #[cfg(windows)]
     raw_sock: std::os::windows::io::RawSocket,
     /// Remote socket address
-    pub peer_addr: OnceCell<Option<SocketAddr>>,
+    pub peer_addr: OnceLock<Option<SocketAddr>>,
     /// Local socket address
-    pub local_addr: OnceCell<Option<SocketAddr>>,
+    pub local_addr: OnceLock<Option<SocketAddr>>,
     /// Original destination address
-    pub original_dst: OnceCell<Option<SocketAddr>>,
+    pub original_dst: OnceLock<Option<SocketAddr>>,
 }
 
 impl SocketDigest {
@@ -95,9 +93,9 @@ impl SocketDigest {
     pub fn from_raw_fd(raw_fd: std::os::unix::io::RawFd) -> SocketDigest {
         SocketDigest {
             raw_fd,
-            peer_addr: OnceCell::new(),
-            local_addr: OnceCell::new(),
-            original_dst: OnceCell::new(),
+            peer_addr: OnceLock::new(),
+            local_addr: OnceLock::new(),
+            original_dst: OnceLock::new(),
         }
     }
 
@@ -105,9 +103,9 @@ impl SocketDigest {
     pub fn from_raw_socket(raw_sock: std::os::windows::io::RawSocket) -> SocketDigest {
         SocketDigest {
             raw_sock,
-            peer_addr: OnceCell::new(),
-            local_addr: OnceCell::new(),
-            original_dst: OnceCell::new(),
+            peer_addr: OnceLock::new(),
+            local_addr: OnceLock::new(),
+            original_dst: OnceLock::new(),
         }
     }
 

--- a/pingora-core/src/protocols/http/compression/mod.rs
+++ b/pingora-core/src/protocols/http/compression/mod.rs
@@ -971,12 +971,12 @@ fn test_will_decompress_agrees_with_response_header_filter() {
     }
 }
 
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 // Allow text, application, font, a few image/ MIME types and binary/octet-stream
 // TODO: fine tune this list
-static MIME_CHECK: Lazy<Regex> = Lazy::new(|| {
+static MIME_CHECK: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(?:text/|application/|font/|image/(?:x-icon|svg\+xml|nd\.microsoft\.icon)|binary/octet-stream)")
         .unwrap()
 });

--- a/pingora-core/src/protocols/http/error_resp.rs
+++ b/pingora-core/src/protocols/http/error_resp.rs
@@ -15,8 +15,8 @@
 //! Error response generating utilities.
 
 use http::header;
-use once_cell::sync::Lazy;
 use pingora_http::ResponseHeader;
+use std::sync::LazyLock;
 
 use super::SERVER_NAME;
 
@@ -36,6 +36,6 @@ pub fn gen_error_response(code: u16) -> ResponseHeader {
 }
 
 /// Pre-generated 502 response
-pub static HTTP_502_RESPONSE: Lazy<ResponseHeader> = Lazy::new(|| gen_error_response(502));
+pub static HTTP_502_RESPONSE: LazyLock<ResponseHeader> = LazyLock::new(|| gen_error_response(502));
 /// Pre-generated 400 response
-pub static HTTP_400_RESPONSE: Lazy<ResponseHeader> = Lazy::new(|| gen_error_response(400));
+pub static HTTP_400_RESPONSE: LazyLock<ResponseHeader> = LazyLock::new(|| gen_error_response(400));

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -21,7 +21,6 @@ use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
 use http::HeaderValue;
 use http::{header, header::AsHeaderName, Method, Version};
 use log::{debug, trace, warn};
-use once_cell::sync::Lazy;
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use pingora_error::{Error, ErrorType::*, OrErr, Result};
 use pingora_http::{IntoCaseHeaderName, RequestHeader, ResponseHeader};
@@ -29,6 +28,7 @@ use pingora_timeout::timeout;
 use regex::bytes::Regex;
 use std::any::Any;
 use std::collections::VecDeque;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -1749,8 +1749,8 @@ impl HttpSession {
 }
 
 // Regex to parse request line that has illegal chars in it
-static REQUEST_LINE_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^\w+ (?P<uri>.+) HTTP/\d(?:\.\d)?").unwrap());
+static REQUEST_LINE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\w+ (?P<uri>.+) HTTP/\d(?:\.\d)?").unwrap());
 
 // the chars httparse considers illegal in URL
 // Almost https://url.spec.whatwg.org/#query-percent-encode-set + {}

--- a/pingora-core/src/protocols/l4/listener.rs
+++ b/pingora-core/src/protocols/l4/listener.rs
@@ -93,7 +93,7 @@ impl Listener {
                 digest
                     .peer_addr
                     .set(Some(peer_addr.into()))
-                    .expect("newly created OnceCell must be empty");
+                    .expect("newly created OnceLock must be empty");
                 s.set_socket_digest(digest);
                 // TODO: if listening on a specific bind address, we could save
                 // an extra syscall looking up the local_addr later if we can pass
@@ -110,7 +110,7 @@ impl Listener {
                 digest
                     .peer_addr
                     .set(addr)
-                    .expect("newly created OnceCell must be empty");
+                    .expect("newly created OnceLock must be empty");
                 s.set_socket_digest(digest);
                 s
             }),

--- a/pingora-core/tests/utils/mod.rs
+++ b/pingora-core/tests/utils/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::{thread, time};
 
 use clap::Parser;
@@ -124,7 +124,7 @@ impl MyServer {
     }
 }
 
-pub static TEST_SERVER: Lazy<MyServer> = Lazy::new(MyServer::start);
+pub static TEST_SERVER: LazyLock<MyServer> = LazyLock::new(MyServer::start);
 
 pub fn init() {
     let _ = *TEST_SERVER;

--- a/pingora-memory-cache/Cargo.toml
+++ b/pingora-memory-cache/Cargo.toml
@@ -25,6 +25,3 @@ pingora-error = { version = "0.8.0", path = "../pingora-error" }
 log = { workspace = true }
 parking_lot = "0"
 pingora-timeout = { version = "0.8.0", path = "../pingora-timeout" }
-
-[dev-dependencies]
-once_cell = { workspace = true }

--- a/pingora-memory-cache/src/read_through.rs
+++ b/pingora-memory-cache/src/read_through.rs
@@ -315,10 +315,8 @@ where
     /// Similar to [Self::get_stale], but when it returns the stale value, it also initiates a lookup
     /// in the background in order to refresh the value.
     ///
-    /// Note that this function requires the [RTCache] to be static, which can be done by wrapping
-    /// it with something like [once_cell::sync::Lazy].
-    ///
-    /// [once_cell::sync::Lazy]: https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html
+    /// This function requires a static [RTCache]. Use [`std::sync::LazyLock`] to initialize one
+    /// when it is first accessed.
     pub async fn get_stale_while_update(
         &'static self,
         key: &K,
@@ -772,10 +770,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_stale_while_update() {
-        use once_cell::sync::Lazy;
+        use std::sync::LazyLock;
         let ttl = Some(Duration::from_millis(100));
-        static CACHE: Lazy<RTCache<i32, i32, TestCB, ExtraOpt>> =
-            Lazy::new(|| RTCache::new(10, None, None));
+        static CACHE: LazyLock<RTCache<i32, i32, TestCB, ExtraOpt>> =
+            LazyLock::new(|| RTCache::new(10, None, None));
         let opt = Some(ExtraOpt {
             error: false,
             empty: false,

--- a/pingora-prometheus/src/lib.rs
+++ b/pingora-prometheus/src/lib.rs
@@ -61,9 +61,9 @@ use pingora_core::services::listening::Service;
 ///
 /// ```rust,ignore
 /// use pingora_prometheus::prometheus::{self, register_int_counter, IntCounter};
-/// use once_cell::sync::Lazy;
+/// use std::sync::LazyLock;
 ///
-/// static REQUESTS: Lazy<IntCounter> = Lazy::new(|| {
+/// static REQUESTS: LazyLock<IntCounter> = LazyLock::new(|| {
 ///     register_int_counter!("requests_total", "Total requests").unwrap()
 /// });
 /// ```

--- a/pingora-proxy/Cargo.toml
+++ b/pingora-proxy/Cargo.toml
@@ -30,7 +30,6 @@ bytes = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 h2 = { workspace = true }
-once_cell = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 regex = "1"
 rand = "0.8"

--- a/pingora-proxy/examples/rate_limiter.rs
+++ b/pingora-proxy/examples/rate_limiter.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
-use once_cell::sync::Lazy;
 use pingora_core::prelude::*;
 use pingora_http::{RequestHeader, ResponseHeader};
 use pingora_limits::rate::Rate;
 use pingora_load_balancing::prelude::{RoundRobin, TcpHealthCheck};
 use pingora_load_balancing::LoadBalancer;
 use pingora_proxy::{http_proxy_service, ProxyHttp, Session};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 fn main() {
@@ -50,7 +49,7 @@ impl LB {
 }
 
 // Rate limiter
-static RATE_LIMITER: Lazy<Rate> = Lazy::new(|| Rate::new(Duration::from_secs(1)));
+static RATE_LIMITER: LazyLock<Rate> = LazyLock::new(|| Rate::new(Duration::from_secs(1)));
 
 // max request per second per client
 static MAX_REQ_PER_SEC: isize = 1;

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -41,13 +41,12 @@ use futures::future::BoxFuture;
 use futures::future::FutureExt;
 use http::{header, version::Version, Method};
 use log::{debug, error, trace, warn};
-use once_cell::sync::Lazy;
 use pingora_http::{RequestHeader, ResponseHeader};
 use std::fmt::Debug;
 use std::str;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
-    Arc,
+    Arc, LazyLock,
 };
 use std::time::Duration;
 use tokio::sync::{mpsc, Notify};
@@ -1014,7 +1013,7 @@ impl DerefMut for Session {
 }
 
 // generic HTTP 502 response sent when proxy_upstream_filter refuses to connect to upstream
-static BAD_GATEWAY: Lazy<ResponseHeader> = Lazy::new(|| {
+static BAD_GATEWAY: LazyLock<ResponseHeader> = LazyLock::new(|| {
     let mut resp = ResponseHeader::build(http::StatusCode::BAD_GATEWAY, Some(3)).unwrap();
     resp.insert_header(header::SERVER, &SERVER_NAME[..])
         .unwrap();

--- a/pingora-proxy/src/proxy_cache.rs
+++ b/pingora-proxy/src/proxy_cache.rs
@@ -1065,8 +1065,8 @@ pub mod range_filter {
         use regex::Regex;
 
         // Match individual range parts, (e.g. "0-100", "-5", "1-")
-        static RE_SINGLE_RANGE_PART: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"(?i)^\s*(?P<start>\d*)-(?P<end>\d*)\s*$").unwrap());
+        static RE_SINGLE_RANGE_PART: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"(?i)^\s*(?P<start>\d*)-(?P<end>\d*)\s*$").unwrap());
 
         // Convert bytes to UTF-8 string
         let range_str = match str::from_utf8(range) {

--- a/pingora-proxy/src/proxy_purge.rs
+++ b/pingora-proxy/src/proxy_purge.rs
@@ -52,12 +52,13 @@ fn gen_purge_response(code: u16) -> ResponseHeader {
     resp
 }
 
-static OK: Lazy<ResponseHeader> = Lazy::new(|| gen_purge_response(200));
-static NOT_FOUND: Lazy<ResponseHeader> = Lazy::new(|| gen_purge_response(404));
+static OK: LazyLock<ResponseHeader> = LazyLock::new(|| gen_purge_response(200));
+static NOT_FOUND: LazyLock<ResponseHeader> = LazyLock::new(|| gen_purge_response(404));
 // for when purge is sent to uncacheable assets
-static NOT_PURGEABLE: Lazy<ResponseHeader> = Lazy::new(|| gen_purge_response(405));
+static NOT_PURGEABLE: LazyLock<ResponseHeader> = LazyLock::new(|| gen_purge_response(405));
 // on cache storage or proxy error
-static INTERNAL_ERROR: Lazy<ResponseHeader> = Lazy::new(|| error_resp::gen_error_response(500));
+static INTERNAL_ERROR: LazyLock<ResponseHeader> =
+    LazyLock::new(|| error_resp::gen_error_response(500));
 
 impl<SV, C> HttpProxy<SV, C>
 where

--- a/pingora-proxy/tests/utils/cert.rs
+++ b/pingora-proxy/tests/utils/cert.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use once_cell::sync::Lazy;
 #[cfg(feature = "s2n")]
 use pingora_core::tls::load_pem_file;
 #[cfg(feature = "rustls")]
@@ -23,6 +22,7 @@ use pingora_core::tls::{
     x509::X509,
 };
 use std::fs;
+use std::sync::LazyLock;
 
 #[cfg(feature = "openssl_derived")]
 mod key_types {
@@ -47,17 +47,20 @@ mod key_types {
 
 use key_types::*;
 
-pub static INTERMEDIATE_CERT: Lazy<CertType> = Lazy::new(|| load_cert("keys/intermediate.crt"));
-pub static LEAF_CERT: Lazy<CertType> = Lazy::new(|| load_cert("keys/leaf.crt"));
-pub static LEAF2_CERT: Lazy<CertType> = Lazy::new(|| load_cert("keys/leaf2.crt"));
-pub static LEAF_KEY: Lazy<PrivateKeyType> = Lazy::new(|| load_key("keys/leaf.key"));
-pub static LEAF2_KEY: Lazy<PrivateKeyType> = Lazy::new(|| load_key("keys/leaf2.key"));
-pub static CURVE_521_TEST_KEY: Lazy<PrivateKeyType> =
-    Lazy::new(|| load_key("keys/curve_test.521.key.pem"));
-pub static CURVE_521_TEST_CERT: Lazy<CertType> = Lazy::new(|| load_cert("keys/curve_test.521.crt"));
-pub static CURVE_384_TEST_KEY: Lazy<PrivateKeyType> =
-    Lazy::new(|| load_key("keys/curve_test.384.key.pem"));
-pub static CURVE_384_TEST_CERT: Lazy<CertType> = Lazy::new(|| load_cert("keys/curve_test.384.crt"));
+pub static INTERMEDIATE_CERT: LazyLock<CertType> =
+    LazyLock::new(|| load_cert("keys/intermediate.crt"));
+pub static LEAF_CERT: LazyLock<CertType> = LazyLock::new(|| load_cert("keys/leaf.crt"));
+pub static LEAF2_CERT: LazyLock<CertType> = LazyLock::new(|| load_cert("keys/leaf2.crt"));
+pub static LEAF_KEY: LazyLock<PrivateKeyType> = LazyLock::new(|| load_key("keys/leaf.key"));
+pub static LEAF2_KEY: LazyLock<PrivateKeyType> = LazyLock::new(|| load_key("keys/leaf2.key"));
+pub static CURVE_521_TEST_KEY: LazyLock<PrivateKeyType> =
+    LazyLock::new(|| load_key("keys/curve_test.521.key.pem"));
+pub static CURVE_521_TEST_CERT: LazyLock<CertType> =
+    LazyLock::new(|| load_cert("keys/curve_test.521.crt"));
+pub static CURVE_384_TEST_KEY: LazyLock<PrivateKeyType> =
+    LazyLock::new(|| load_key("keys/curve_test.384.key.pem"));
+pub static CURVE_384_TEST_CERT: LazyLock<CertType> =
+    LazyLock::new(|| load_cert("keys/curve_test.384.crt"));
 
 #[cfg(feature = "openssl_derived")]
 fn load_cert(path: &str) -> X509 {

--- a/pingora-proxy/tests/utils/mock_origin.rs
+++ b/pingora-proxy/tests/utils/mock_origin.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use once_cell::sync::Lazy;
 use std::path::Path;
 use std::process;
+use std::sync::LazyLock;
 use std::{thread, time};
 
-pub static MOCK_ORIGIN: Lazy<bool> = Lazy::new(init);
+pub static MOCK_ORIGIN: LazyLock<bool> = LazyLock::new(init);
 
 fn init() -> bool {
     #[cfg(feature = "rustls")]

--- a/pingora-proxy/tests/utils/mod.rs
+++ b/pingora-proxy/tests/utils/mod.rs
@@ -21,13 +21,13 @@ pub mod mock_origin;
 pub mod server_utils;
 pub mod websocket;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use tokio::runtime::{Builder, Runtime};
 
 // for tests with a static connection pool, if we use tokio::test the reactor
 // will no longer be associated with the backing pool fds since it's dropped per test
-pub static GLOBAL_RUNTIME: Lazy<Runtime> =
-    Lazy::new(|| Builder::new_multi_thread().enable_all().build().unwrap());
+pub static GLOBAL_RUNTIME: LazyLock<Runtime> =
+    LazyLock::new(|| Builder::new_multi_thread().enable_all().build().unwrap());
 
 pub fn conf_dir() -> String {
     format!("{}/tests/utils/conf", env!("CARGO_MANIFEST_DIR"))

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -19,7 +19,6 @@ use clap::Parser;
 use http::header::{ACCEPT_ENCODING, CONNECTION, CONTENT_LENGTH, TRANSFER_ENCODING, UPGRADE, VARY};
 use http::HeaderValue;
 use log::error;
-use once_cell::sync::Lazy;
 use pingora_cache::admission::{AdmissionPolicy, Decision};
 use pingora_cache::cache_control::CacheControl;
 use pingora_cache::hashtable::ConcurrentHashTable;
@@ -49,7 +48,7 @@ use pingora_proxy::{FailToProxy, ProxyHttp, ProxyWarnLogContext, Session};
 use std::collections::{HashMap, HashSet};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc,
+    Arc, LazyLock,
 };
 use std::thread;
 use std::time::{Duration, SystemTime};
@@ -483,18 +482,18 @@ impl ProxyHttp for ExampleProxyHttp {
     }
 }
 
-static CACHE_BACKEND: Lazy<MemCache> = Lazy::new(MemCache::new);
+static CACHE_BACKEND: LazyLock<MemCache> = LazyLock::new(MemCache::new);
 static CACHE_FINISH_FAIL_BACKEND: FinishFailCache = FinishFailCache;
 const CACHE_DEFAULT: CacheMetaDefaults =
     CacheMetaDefaults::new(|_| Some(Duration::from_secs(1)), 1, 1);
-static CACHE_PREDICTOR: Lazy<Predictor<32>> = Lazy::new(|| Predictor::new(5, None));
-static EVICTION_MANAGER: Lazy<Manager> = Lazy::new(|| Manager::new(8192)); // 8192 bytes
-static CACHE_LOCK: Lazy<Box<CacheKeyLockImpl>> =
-    Lazy::new(|| CacheLock::new_boxed(std::time::Duration::from_secs(2)));
+static CACHE_PREDICTOR: LazyLock<Predictor<32>> = LazyLock::new(|| Predictor::new(5, None));
+static EVICTION_MANAGER: LazyLock<Manager> = LazyLock::new(|| Manager::new(8192)); // 8192 bytes
+static CACHE_LOCK: LazyLock<Box<CacheKeyLockImpl>> =
+    LazyLock::new(|| CacheLock::new_boxed(std::time::Duration::from_secs(2)));
 static DEFER_ADMISSION_POLICY: DeferAdmissionPolicy = DeferAdmissionPolicy;
 // Example of how one might restrict which fields can be varied on.
-static CACHE_VARY_ALLOWED_HEADERS: Lazy<Option<HashSet<&str>>> =
-    Lazy::new(|| Some(vec!["accept", "accept-encoding"].into_iter().collect()));
+static CACHE_VARY_ALLOWED_HEADERS: LazyLock<Option<HashSet<&str>>> =
+    LazyLock::new(|| Some(vec!["accept", "accept-encoding"].into_iter().collect()));
 
 struct DeferAdmissionPolicy;
 
@@ -1159,9 +1158,9 @@ impl PskTlsServer {
 }
 
 // FIXME: this still allows multiple servers to spawn across integration tests
-pub static TEST_SERVER: Lazy<Server> = Lazy::new(Server::start);
+pub static TEST_SERVER: LazyLock<Server> = LazyLock::new(Server::start);
 #[cfg(feature = "s2n")]
-pub static TEST_PSK_TLS_SERVER: Lazy<PskTlsServer> = Lazy::new(PskTlsServer::start);
+pub static TEST_PSK_TLS_SERVER: LazyLock<PskTlsServer> = LazyLock::new(PskTlsServer::start);
 use super::mock_origin::MOCK_ORIGIN;
 
 pub fn init() {

--- a/pingora-runtime/Cargo.toml
+++ b/pingora-runtime/Cargo.toml
@@ -22,7 +22,6 @@ workspace = true
 [dependencies]
 rand = "0.8"
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
-once_cell = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thread_local = "1"
 log = { workspace = true }

--- a/pingora-runtime/src/lib.rs
+++ b/pingora-runtime/src/lib.rs
@@ -23,12 +23,11 @@
 //! This flavor is as efficient as the single-threaded runtime while allows the async
 //! program to use multiple cores.
 
-use once_cell::sync::{Lazy, OnceCell};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "dial9")]
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, OnceLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 use thread_local::ThreadLocal;
@@ -566,7 +565,7 @@ impl Runtime {
 }
 
 // only NoStealRuntime set the pools in thread threads
-static CURRENT_HANDLE: Lazy<ThreadLocal<Pools>> = Lazy::new(ThreadLocal::new);
+static CURRENT_HANDLE: LazyLock<ThreadLocal<Pools>> = LazyLock::new(ThreadLocal::new);
 
 /// Return the [Handle] of current runtime.
 /// If the current thread is under a `Steal` runtime, the current [Handle] is returned.
@@ -586,7 +585,7 @@ pub fn current_handle() -> Handle {
 }
 
 type Control = (Sender<Duration>, JoinHandle<()>);
-type Pools = Arc<OnceCell<Box<[Handle]>>>;
+type Pools = Arc<OnceLock<Box<[Handle]>>>;
 
 /// Multi-threaded runtime backed by a pool of single threaded tokio runtime
 pub struct NoStealRuntime {
@@ -597,7 +596,7 @@ pub struct NoStealRuntime {
     // Lazily init the runtimes so that they are created after pingora
     // daemonize itself. Otherwise the runtime threads are lost.
     pools: Pools,
-    controls: OnceCell<Vec<Control>>,
+    controls: OnceLock<Vec<Control>>,
 }
 
 impl NoStealRuntime {
@@ -614,8 +613,8 @@ impl NoStealRuntime {
             name: name.to_string(),
             blocking_opts,
             runtime_opts,
-            pools: Arc::new(OnceCell::new()),
-            controls: OnceCell::new(),
+            pools: Arc::new(OnceLock::new()),
+            controls: OnceLock::new(),
         }
     }
 
@@ -669,15 +668,15 @@ impl NoStealRuntime {
             // TODO: use a mutex to avoid creating a lot threads only to drop them
             let (pools, controls) = self.init_pools();
             // there could be another thread racing with this one to init the pools
-            match self.pools.try_insert(pools) {
-                Ok(p) => {
+            match self.pools.set(pools) {
+                Ok(()) => {
                     // unwrap to make sure that this is the one that init both pools and controls
                     self.controls.set(controls).unwrap();
-                    p
                 }
-                // another thread already set it, just return it
-                Err((p, _my_pools)) => p,
+                // another thread already set it, just use that thread's pools
+                Err(_my_pools) => {}
             }
+            self.pools.get().unwrap()
         }
     }
 
@@ -762,6 +761,42 @@ fn test_no_steal_shutdown() {
     assert_eq!(ret, 1);
 
     rt.shutdown_timeout(Duration::from_secs(1));
+}
+
+#[test]
+fn test_no_steal_runtime_concurrent_initialization() {
+    use std::sync::Barrier;
+
+    let runtime = Arc::new(NoStealRuntime::new(
+        2,
+        "test",
+        BlockingPoolOpts::default(),
+        RuntimeOpts::default(),
+    ));
+    let barrier = Arc::new(Barrier::new(5));
+    let mut threads = Vec::new();
+
+    for _ in 0..4 {
+        let runtime = runtime.clone();
+        let barrier = barrier.clone();
+        threads.push(std::thread::spawn(move || {
+            barrier.wait();
+            runtime.get_runtime_at(0).clone()
+        }));
+    }
+    barrier.wait();
+
+    for thread in threads {
+        let _ = thread.join().unwrap();
+    }
+
+    assert!(runtime.pools.get().is_some());
+    assert!(runtime.controls.get().is_some());
+    let runtime = match Arc::try_unwrap(runtime) {
+        Ok(runtime) => runtime,
+        Err(_) => panic!("runtime still has shared owners after initialization"),
+    };
+    runtime.shutdown_timeout(Duration::from_secs(1));
 }
 
 #[cfg(feature = "dial9")]

--- a/pingora-timeout/Cargo.toml
+++ b/pingora-timeout/Cargo.toml
@@ -24,7 +24,6 @@ tokio = { workspace = true, features = [
     "sync",
 ] }
 pin-project-lite = "0.2"
-once_cell = { workspace = true }
 parking_lot = "0.12"
 thread_local = "1.0"
 

--- a/pingora-timeout/src/fast_timeout.rs
+++ b/pingora-timeout/src/fast_timeout.rs
@@ -26,11 +26,10 @@
 
 use super::timer::*;
 use super::*;
-use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
-static TIMER_MANAGER: Lazy<Arc<TimerManager>> = Lazy::new(|| {
+static TIMER_MANAGER: LazyLock<Arc<TimerManager>> = LazyLock::new(|| {
     let tm = Arc::new(TimerManager::new());
     check_clock_thread(&tm);
     tm

--- a/pingora/Cargo.toml
+++ b/pingora/Cargo.toml
@@ -47,7 +47,6 @@ http = { workspace = true }
 log = { workspace = true }
 pingora-prometheus = { version = "0.8.0", path = "../pingora-prometheus" }
 prometheus = "0.14"
-once_cell = { workspace = true }
 bytes = { workspace = true }
 regex = "1"
 

--- a/pingora/examples/app/echo.rs
+++ b/pingora/examples/app/echo.rs
@@ -16,10 +16,9 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Response, StatusCode};
 use log::debug;
-use once_cell::sync::Lazy;
 use pingora_timeout::timeout;
 use prometheus::{register_int_counter, IntCounter};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -29,8 +28,8 @@ use pingora::protocols::http::ServerSession;
 use pingora::protocols::Stream;
 use pingora::server::ShutdownWatch;
 
-static REQ_COUNTER: Lazy<IntCounter> =
-    Lazy::new(|| register_int_counter!("reg_counter", "Number of requests").unwrap());
+static REQ_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| register_int_counter!("reg_counter", "Number of requests").unwrap());
 
 #[derive(Clone)]
 pub struct EchoApp;


### PR DESCRIPTION
Closes #721.

This is a current-`main` replacement for #732 and #735, which now conflict with the base branch.

## Summary

- Replace Pingora's direct uses of `once_cell::sync::Lazy` and `OnceCell` with `std::sync::LazyLock` and `OnceLock`.
- Preserve concurrent runtime initialization by using `OnceLock::set` followed by `get`, and add a test that initializes a no-steal runtime from four threads.
- Update examples and user guides to use the standard-library types, then remove the direct `once_cell` declarations from the workspace crates.

`once_cell` can still appear transitively through third-party crates; this change removes Pingora's direct dependency on it.

## Testing

- `cargo fmt --all -- --check`
- `cargo +1.85.0 check --workspace --exclude pingora-foundations`
- `cargo check --workspace`
- `cargo test -p pingora-runtime test_no_steal_runtime_concurrent_initialization -- --nocapture`
- `cargo test --doc`
- `cargo clippy --all-targets --all -- --allow=unknown-lints --deny=warnings`
- `cargo machete`

The full library, binary, and integration test command passed all targets that do not require OpenResty. The local host does not have OpenResty, so `pingora-proxy`'s `test_basic` and `test_upstream` targets could not start their mock origin; the repository CI installs OpenResty before running them.
