### PR TITLE
Shard the HttpProxy shutdown Notify to cut lock contention

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,14 @@
-# Advisories against rustls-webpki 0.101.7, pulled in transitively by
-# aws-sdk-s3-transfer-manager through the legacy rustls 0.21 chain used by
-# dial9's worker-s3 feature. No patch exists in 0.101.x; not reachable in
-# our usage because this is TLS client use only and does not parse CRLs.
-# Remove once the upstream aws-s3-transfer-manager-rs fix ships.
+# Advisories against rustls-webpki 0.101.7 and h2 0.3.x, pulled in transitively
+# by aws-sdk-s3-transfer-manager through the legacy hyper 0.14 / rustls 0.21
+# chain used by dial9's worker-s3 feature. No patches exist in those release
+# lines; not reachable in our usage because this is TLS client use only against
+# trusted AWS endpoints, does not parse CRLs, and is not exposed to untrusted
+# HTTP/2 peers. Remove once the upstream aws-s3-transfer-manager-rs fix ships.
 
 [advisories]
 ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints incorrectly accepted
     "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certs
     "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+    "RUSTSEC-2026-0258", # h2 0.3: unbounded empty DATA frames
 ]

--- a/pingora-proxy/src/lib.rs
+++ b/pingora-proxy/src/lib.rs
@@ -46,7 +46,7 @@ use pingora_http::{RequestHeader, ResponseHeader};
 use std::fmt::Debug;
 use std::str;
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
+    atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
     Arc,
 };
 use std::time::Duration;
@@ -108,6 +108,51 @@ pub type ProcessCustomSession<SV, C> = Arc<
         + 'static,
 >;
 
+/// Shutdown [`Notify`] sharded by worker thread.
+///
+/// Every request that parks in `read_request()` registers a shutdown waiter and
+/// unregisters it when the read completes. Both operations lock the `Notify`'s
+/// internal mutex, so a single `Notify` shared across the whole proxy becomes a
+/// contention hot spot on many-core machines. Sharding keeps waiter
+/// registration on a (mostly) thread-local shard while shutdown notifies every
+/// shard.
+struct ShardedNotify {
+    shards: Box<[NotifyShard]>,
+}
+
+/// Cache line aligned to avoid false sharing between adjacent shards.
+#[repr(align(128))]
+struct NotifyShard(Notify);
+
+impl ShardedNotify {
+    fn new() -> Self {
+        let shards = std::thread::available_parallelism()
+            .map_or(1, usize::from)
+            .next_power_of_two()
+            .min(256);
+        ShardedNotify {
+            shards: (0..shards).map(|_| NotifyShard(Notify::new())).collect(),
+        }
+    }
+
+    /// The shard assigned to the current thread.
+    fn local(&self) -> &Notify {
+        static NEXT_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+        thread_local! {
+            static THREAD_ID: usize = NEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+        }
+        let id = THREAD_ID.with(|id| *id);
+        // the shard count is a power of two
+        &self.shards[id & (self.shards.len() - 1)].0
+    }
+
+    fn notify_waiters(&self) {
+        for shard in self.shards.iter() {
+            shard.0.notify_waiters();
+        }
+    }
+}
+
 /// The concrete type that holds the user defined HTTP proxy.
 ///
 /// Users don't need to interact with this object directly.
@@ -117,7 +162,7 @@ where
 {
     inner: SV, // TODO: name it better than inner
     client_upstream: Connector<C>,
-    shutdown: Notify,
+    shutdown: ShardedNotify,
     shutdown_flag: Arc<AtomicBool>,
     pub server_options: Option<HttpServerOptions>,
     pub h2_options: Option<H2Options>,
@@ -153,7 +198,7 @@ impl<SV> HttpProxy<SV, ()> {
         HttpProxy {
             inner,
             client_upstream: Connector::new(Some(ConnectorOptions::from_server_conf(&conf))),
-            shutdown: Notify::new(),
+            shutdown: ShardedNotify::new(),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             server_options: None,
             h2_options: None,
@@ -189,7 +234,7 @@ where
         HttpProxy {
             inner,
             client_upstream,
-            shutdown: Notify::new(),
+            shutdown: ShardedNotify::new(),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             server_options,
             downstream_modules: HttpModules::new(),
@@ -230,6 +275,21 @@ where
         self.inner.init_upstream_modules(&mut self.upstream_modules);
     }
 
+    /// Resolve when `http_cleanup()` has been called.
+    ///
+    /// The waiter is registered on the current thread's shard before
+    /// `shutdown_flag` is checked, so a shutdown firing in between cannot be
+    /// missed: either the flag load sees the store, or the registered waiter
+    /// receives the notification.
+    async fn await_shutdown(&self) {
+        let mut notified = std::pin::pin!(self.shutdown.local().notified());
+        notified.as_mut().enable();
+        if self.shutdown_flag.load(Ordering::Acquire) {
+            return;
+        }
+        notified.await;
+    }
+
     async fn handle_new_request(
         &self,
         mut downstream_session: Box<HttpSession>,
@@ -243,7 +303,7 @@ where
         let res = tokio::select! {
             biased; // biased select is cheaper, and we don't want to drop already buffered requests
             res = downstream_session.read_request() => { res }
-            _ = self.shutdown.notified() => {
+            _ = self.await_shutdown() => {
                 // service shutting down, dropping the connection to stop more req from coming in
                 return None;
             }
@@ -2279,5 +2339,100 @@ mod tests {
         assert!(called.load(Ordering::Acquire));
         let written = written.lock().unwrap().clone();
         assert_raw_upgrade_payload(&written);
+    }
+
+    /// A socket whose reads never complete, like an idle keep-alive connection
+    /// waiting for its next request.
+    #[derive(Debug)]
+    struct PendingVirtualSocket;
+
+    impl AsyncRead for PendingVirtualSocket {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    impl AsyncWrite for PendingVirtualSocket {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl VirtualSocket for PendingVirtualSocket {
+        fn set_socket_option(&self, _opt: VirtualSockOpt) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct NoopProxy;
+
+    #[async_trait]
+    impl ProxyHttp for NoopProxy {
+        type CTX = ();
+        fn new_ctx(&self) -> Self::CTX {}
+        async fn upstream_peer(
+            &self,
+            _session: &mut Session,
+            _ctx: &mut Self::CTX,
+        ) -> Result<Box<HttpPeer>> {
+            Err(Error::new(InternalError))
+        }
+    }
+
+    fn pending_session() -> Box<HttpSession> {
+        let stream = L4Stream::from(VirtualSocketStream::new(Box::new(PendingVirtualSocket)));
+        Box::new(HttpSession::new_http1(Box::new(stream)))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shutdown_wakes_parked_read_requests() {
+        let proxy = Arc::new(HttpProxy::new(NoopProxy, Arc::new(ServerConf::default())));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let proxy = proxy.clone();
+                tokio::spawn(async move { proxy.handle_new_request(pending_session()).await })
+            })
+            .collect();
+        // let the tasks park in read_request()
+        time::sleep(Duration::from_millis(50)).await;
+        proxy.http_cleanup().await;
+        for handle in handles {
+            let session = time::timeout(Duration::from_secs(5), handle)
+                .await
+                .expect("shutdown did not wake the parked read")
+                .unwrap();
+            assert!(session.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_before_read_request_parks_returns_immediately() {
+        let proxy = Arc::new(HttpProxy::new(NoopProxy, Arc::new(ServerConf::default())));
+        proxy.http_cleanup().await;
+        // a request that parks after notify_waiters() already fired must not
+        // wait for a notification that will never come
+        let session = time::timeout(
+            Duration::from_secs(5),
+            proxy.handle_new_request(pending_session()),
+        )
+        .await
+        .expect("read_request parked after shutdown");
+        assert!(session.is_none());
     }
 }


### PR DESCRIPTION
Fixes #844.

Every request that parks in `read_request()` registers a shutdown waiter on a single `Notify` shared by the whole proxy, and unregisters it when the read completes. Both operations serialize on the `Notify`'s internal mutex, which becomes the scaling bottleneck on many-core machines: #844 measured ~65% of off-CPU time in futex waits on a 128-core NUMA host.

This change shards the `Notify` by worker thread (cache-line padded, power-of-two count from `available_parallelism`, capped at 256). Waiter registration stays on a core-local shard; `http_cleanup()` notifies all shards. Streams whose headers are already buffered (h2 streams, pipelined h1) never touch the `Notify` at all because the biased select polls `read_request()` first.

It also closes a pre-existing lost-wakeup race: `handle_new_request()` never checked `shutdown_flag`, so a `notify_waiters()` that fired between `read_request()` returning Pending and the waiter registering was missed, and the connection lingered until the grace period expired. The shutdown arm now registers the waiter first (`Notified::enable`), then checks `shutdown_flag` before awaiting. The two lock the same shard mutex, so either the flag load sees the store or the waiter receives the notification.

Semantics are otherwise unchanged: connections parked in `read_request()` are still woken immediately on shutdown, and in-flight requests are never aborted.

Two tests added:
- `shutdown_wakes_parked_read_requests`: parked keep-alive reads across multiple worker threads all wake on `http_cleanup()`. This is the behavior the flag-only fix proposed in #844 would break.
- `shutdown_before_read_request_parks_returns_immediately`: regression test for the lost-wakeup race. It hangs on current main.