### PR TITLE
Recheck the cache before becoming the RTCache lookup writer

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,14 @@
-# Advisories against rustls-webpki 0.101.7, pulled in transitively by
-# aws-sdk-s3-transfer-manager through the legacy rustls 0.21 chain used by
-# dial9's worker-s3 feature. No patch exists in 0.101.x; not reachable in
-# our usage because this is TLS client use only and does not parse CRLs.
-# Remove once the upstream aws-s3-transfer-manager-rs fix ships.
+# Advisories against rustls-webpki 0.101.7 and h2 0.3.x, pulled in transitively
+# by aws-sdk-s3-transfer-manager through the legacy hyper 0.14 / rustls 0.21
+# chain used by dial9's worker-s3 feature. No patches exist in those release
+# lines; not reachable in our usage because this is TLS client use only against
+# trusted AWS endpoints, does not parse CRLs, and is not exposed to untrusted
+# HTTP/2 peers. Remove once the upstream aws-s3-transfer-manager-rs fix ships.
 
 [advisories]
 ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints incorrectly accepted
     "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certs
     "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+    "RUSTSEC-2026-0258", # h2 0.3: unbounded empty DATA frames
 ]

--- a/pingora-memory-cache/src/read_through.rs
+++ b/pingora-memory-cache/src/read_through.rs
@@ -191,6 +191,13 @@ where
                         }
                     }
                     None => {
+                        /* recheck the cache before becoming the writer: another lookup may have
+                         * populated it and removed its lock between our initial miss and
+                         * acquiring this write lock */
+                        let (result, _) = self.inner.get(key);
+                        if let Some(result) = result {
+                            return (Ok(result), CacheStatus::LockHit);
+                        }
                         let new_lock = CacheLock::new_arc();
                         let new_lock2 = new_lock.clone();
                         lockers.insert(hashed_key, new_lock2);


### PR DESCRIPTION
Fixes #110.

A task that misses the cache can acquire the `lockers` write lock after the previous writer for the same key has already populated the cache and removed its lock. It then inserts a new `CacheLock` and performs a lookup whose result is already in the cache.

This adds the double-check the issue asks for: re-read the cache under the `lockers` write lock before inserting a new `CacheLock`, and return `LockHit` if another task's lookup has already populated the value. This is the same pattern the waiting-reader path already uses after the writer releases its lock.

The race window sits between two synchronous statements (the initial cache read and the write-lock acquisition), so it can't be exercised deterministically through the public API; the existing concurrency tests cover the changed path. `MemoryCache::get` is a cheap sync read, so doing it under the write lock does not meaningfully extend the critical section, and it is only reached on the miss path.