### PR TITLE
Make pooled virtual L4 streams reusable

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,14 @@
-# Advisories against rustls-webpki 0.101.7, pulled in transitively by
-# aws-sdk-s3-transfer-manager through the legacy rustls 0.21 chain used by
-# dial9's worker-s3 feature. No patch exists in 0.101.x; not reachable in
-# our usage because this is TLS client use only and does not parse CRLs.
-# Remove once the upstream aws-s3-transfer-manager-rs fix ships.
+# Advisories against rustls-webpki 0.101.7 and h2 0.3.x, pulled in transitively
+# by aws-sdk-s3-transfer-manager through the legacy hyper 0.14 / rustls 0.21
+# chain used by dial9's worker-s3 feature. No patches exist in those release
+# lines; not reachable in our usage because this is TLS client use only against
+# trusted AWS endpoints, does not parse CRLs, and is not exposed to untrusted
+# HTTP/2 peers. Remove once the upstream aws-s3-transfer-manager-rs fix ships.
 
 [advisories]
 ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints incorrectly accepted
     "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certs
     "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+    "RUSTSEC-2026-0258", # h2 0.3: unbounded empty DATA frames
 ]

--- a/pingora-core/src/connectors/mod.rs
+++ b/pingora-core/src/connectors/mod.rs
@@ -261,12 +261,25 @@ impl TransportConnector {
                         // test_reusable_stream: we assume server would never actively send data
                         // first on an idle stream.
                         #[cfg(unix)]
-                        if peer.matches_fd(stream.id())
-                            && test_reusable_stream(&mut stream, &self.unexpected_data_conn_count)
                         {
-                            Some(stream)
-                        } else {
-                            None
+                            let id = stream.id();
+                            // Virtual streams have negative IDs and no real fd to getpeername(),
+                            // so compare the peer address recorded in their socket digest instead.
+                            let peer_match = if id < 0 {
+                                virtual_stream_peer_match(&stream, peer)
+                            } else {
+                                peer.matches_fd(id)
+                            };
+                            if peer_match
+                                && test_reusable_stream(
+                                    &mut stream,
+                                    &self.unexpected_data_conn_count,
+                                )
+                            {
+                                Some(stream)
+                            } else {
+                                None
+                            }
                         }
                         #[cfg(windows)]
                         {
@@ -470,6 +483,36 @@ impl PreferredHttpVersion {
 
 use futures::future::FutureExt;
 use tokio::io::AsyncReadExt;
+
+/// Test whether a pooled virtual stream is connected to the given peer.
+///
+/// Virtual streams have no real fd for a `getpeername()` check, so this compares the peer
+/// address recorded in the stream's socket digest when it was created. Streams without a
+/// recorded peer address are never reused.
+#[cfg(unix)]
+fn virtual_stream_peer_match<P: Peer>(stream: &Stream, peer: &P) -> bool {
+    let Some(digest) = stream.get_socket_digest() else {
+        debug!("Pooled virtual stream has no socket digest, not reusable");
+        return false;
+    };
+    match digest.peer_addr() {
+        Some(addr) if addr == peer.address() => {
+            debug!("Virtual stream to {addr} is reusable");
+            true
+        }
+        Some(addr) => {
+            error!(
+                "Crit: virtual stream mismatch: stream: {addr}, peer: {}",
+                peer.address()
+            );
+            false
+        }
+        None => {
+            debug!("Pooled virtual stream has no peer address, not reusable");
+            false
+        }
+    }
+}
 
 /// Test whether a stream is already closed or not reusable (server sent unexpected data)
 fn test_reusable_stream(stream: &mut Stream, unexpected_data_conn_count: &AtomicU64) -> bool {
@@ -835,5 +878,113 @@ mod tests {
             1,
             "unexpected_data_connection_count should have incremented"
         );
+    }
+
+    #[cfg(unix)]
+    mod virtual_stream_reuse {
+        use super::*;
+        use crate::protocols::l4::stream::Stream as L4Stream;
+        use crate::protocols::l4::virt::{VirtualSockOpt, VirtualSocket, VirtualSocketStream};
+        use crate::protocols::{SocketDigest, UniqueID};
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+        use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+        /// A virtual socket that stays idle: reads park forever and writes succeed.
+        #[derive(Debug)]
+        struct IdleVirtualSocket;
+
+        impl AsyncRead for IdleVirtualSocket {
+            fn poll_read(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                _buf: &mut ReadBuf<'_>,
+            ) -> Poll<std::io::Result<()>> {
+                Poll::Pending
+            }
+        }
+
+        impl AsyncWrite for IdleVirtualSocket {
+            fn poll_write(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                buf: &[u8],
+            ) -> Poll<std::io::Result<usize>> {
+                Poll::Ready(Ok(buf.len()))
+            }
+
+            fn poll_flush(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<std::io::Result<()>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn poll_shutdown(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<std::io::Result<()>> {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        impl VirtualSocket for IdleVirtualSocket {
+            fn set_socket_option(&self, _opt: VirtualSockOpt) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        fn new_virtual_stream(peer: Option<&BasicPeer>) -> Stream {
+            let mut stream = L4Stream::from(VirtualSocketStream::new(Box::new(IdleVirtualSocket)));
+            if let Some(peer) = peer {
+                let digest = SocketDigest::from_raw_fd(-1);
+                digest.peer_addr.set(Some(peer.address().clone())).unwrap();
+                stream.set_socket_digest(digest);
+            }
+            Box::new(stream)
+        }
+
+        #[test]
+        fn test_virtual_stream_ids_are_unique() {
+            let s1 = new_virtual_stream(None);
+            let s2 = new_virtual_stream(None);
+            assert!(s1.id() < -1);
+            assert!(s2.id() < -1);
+            assert_ne!(s1.id(), s2.id());
+        }
+
+        #[tokio::test]
+        async fn test_virtual_stream_reuse() {
+            let connector = TransportConnector::new(None);
+            let peer = BasicPeer::new("192.0.2.1:80");
+
+            let stream = new_virtual_stream(Some(&peer));
+            connector.release_stream(stream, peer.reuse_hash(), None);
+            assert!(connector.reused_stream(&peer).await.is_some());
+            // the stream was taken out of the pool
+            assert!(connector.reused_stream(&peer).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn test_virtual_stream_wrong_peer_not_reused() {
+            let connector = TransportConnector::new(None);
+            let peer = BasicPeer::new("192.0.2.1:80");
+            let other = BasicPeer::new("192.0.2.2:80");
+
+            // pool a stream to `peer` under `other`'s key, as a reuse_hash collision would
+            let stream = new_virtual_stream(Some(&peer));
+            connector.release_stream(stream, other.reuse_hash(), None);
+            assert!(connector.reused_stream(&other).await.is_none());
+        }
+
+        #[tokio::test]
+        async fn test_virtual_stream_without_digest_not_reused() {
+            let connector = TransportConnector::new(None);
+            let peer = BasicPeer::new("192.0.2.1:80");
+
+            let stream = new_virtual_stream(None);
+            connector.release_stream(stream, peer.reuse_hash(), None);
+            assert!(connector.reused_stream(&peer).await.is_none());
+        }
     }
 }

--- a/pingora-core/src/protocols/l4/stream.rs
+++ b/pingora-core/src/protocols/l4/stream.rs
@@ -630,14 +630,20 @@ impl AsRawSocket for Stream {
 #[cfg(unix)]
 impl UniqueID for Stream {
     fn id(&self) -> UniqueIDType {
-        self.as_raw_fd()
+        match &self.stream().get_ref().stream {
+            RawStream::Virtual(s) => s.id(),
+            _ => self.as_raw_fd(),
+        }
     }
 }
 
 #[cfg(windows)]
 impl UniqueID for Stream {
     fn id(&self) -> usize {
-        self.as_raw_socket() as usize
+        match &self.stream().get_ref().stream {
+            RawStream::Virtual(s) => s.id(),
+            _ => self.as_raw_socket() as usize,
+        }
     }
 }
 

--- a/pingora-core/src/protocols/l4/virt.rs
+++ b/pingora-core/src/protocols/l4/virt.rs
@@ -2,12 +2,14 @@
 
 use std::{
     pin::Pin,
+    sync::atomic::{AtomicU32, Ordering},
     task::{Context, Poll},
 };
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::ext::TcpKeepalive;
+use crate::protocols::UniqueIDType;
 
 /// A limited set of socket options that can be set on a [`VirtualSocket`].
 #[non_exhaustive]
@@ -27,17 +29,49 @@ pub trait VirtualSocket: AsyncRead + AsyncWrite + Unpin + Send + Sync + std::fmt
 #[derive(Debug)]
 pub struct VirtualSocketStream {
     pub(crate) socket: Box<dyn VirtualSocket>,
+    id: UniqueIDType,
 }
 
 impl VirtualSocketStream {
     pub fn new(socket: Box<dyn VirtualSocket>) -> Self {
-        Self { socket }
+        Self {
+            socket,
+            id: next_id(),
+        }
     }
 
     #[inline]
     pub fn set_socket_option(&self, opt: VirtualSockOpt) -> std::io::Result<()> {
         self.socket.set_socket_option(opt)
     }
+
+    /// The unique ID of this stream.
+    ///
+    /// Virtual streams have no real fd, so IDs are allocated from a range no
+    /// real fd or socket handle can occupy. This keeps pooled virtual streams
+    /// distinguishable from each other and from real connections.
+    pub fn id(&self) -> UniqueIDType {
+        self.id
+    }
+}
+
+/// Allocate IDs counting down from -2: real fds are non-negative and -1 is the
+/// "no fd" sentinel, so this range can never collide with either.
+#[cfg(unix)]
+fn next_id() -> UniqueIDType {
+    static NEXT: AtomicU32 = AtomicU32::new(0);
+    // stay within [0, i32::MAX - 1] so the ID below stays within [i32::MIN, -2]
+    let n = NEXT.fetch_add(1, Ordering::Relaxed) % (i32::MAX as u32);
+    -2 - (n as i32)
+}
+
+/// Allocate IDs counting down from usize::MAX - 1: real socket handles are
+/// small values and usize::MAX is INVALID_SOCKET, so this range can never
+/// collide with either.
+#[cfg(windows)]
+fn next_id() -> UniqueIDType {
+    static NEXT: AtomicU32 = AtomicU32::new(0);
+    usize::MAX - 1 - (NEXT.fetch_add(1, Ordering::Relaxed) as usize)
 }
 
 impl AsyncRead for VirtualSocketStream {


### PR DESCRIPTION
Fixes #883.

Virtual streams report fd -1, so the fd-based reuse check in `reused_stream()` always fails at `getpeername()` and pooled virtual streams can never be reused. The shared -1 id also breaks pool bookkeeping: `ConnectionMeta` keys connections by (group, id) and `PoolNode` stores them in a `HashMap` by id, so pooling a second virtual stream under the same group key silently overwrites the first.

Two changes:

- Every virtual stream gets a unique ID from a range no real fd can occupy: counting down from -2 on unix (-1 stays the "no fd" sentinel), from `usize::MAX - 1` on windows (`usize::MAX` is INVALID_SOCKET). `as_raw_fd()` still returns -1 since there is no real fd.
- In `reused_stream()`, a negative ID routes to an address comparison instead of `getpeername()`: the peer address recorded in the stream's socket digest must equal the peer's address. `SocketDigest::peer_addr` is a public `OnceCell`, so creators of virtual streams opt in by presetting it (e.g. `SocketDigest::from_raw_fd(-1)` + `peer_addr.set(...)`), which also keeps the lazy `getpeername` from running. Streams without a recorded peer address are never reused, so existing virtual streams keep today's behavior.

The address comparison is unix-only; on windows virtual streams remain non-reusable as today (the `matches_sock` check fails on the synthetic handle), but the unique IDs fix the pool overwrite there too.

Tests: unique/negative IDs; a pooled virtual stream with a matching recorded peer address is reused exactly once; a stream pooled under another peer's key (as a `reuse_hash` collision would) is rejected; a stream without a digest is rejected.