### PR TITLE
Ignore RUSTSEC-2026-0258 in cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,14 @@
-# Advisories against rustls-webpki 0.101.7, pulled in transitively by
-# aws-sdk-s3-transfer-manager through the legacy rustls 0.21 chain used by
-# dial9's worker-s3 feature. No patch exists in 0.101.x; not reachable in
-# our usage because this is TLS client use only and does not parse CRLs.
-# Remove once the upstream aws-s3-transfer-manager-rs fix ships.
+# Advisories against rustls-webpki 0.101.7 and h2 0.3.x, pulled in transitively
+# by aws-sdk-s3-transfer-manager through the legacy hyper 0.14 / rustls 0.21
+# chain used by dial9's worker-s3 feature. No patches exist in those release
+# lines; not reachable in our usage because this is TLS client use only against
+# trusted AWS endpoints, does not parse CRLs, and is not exposed to untrusted
+# HTTP/2 peers. Remove once the upstream aws-s3-transfer-manager-rs fix ships.
 
 [advisories]
 ignore = [
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints incorrectly accepted
     "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certs
     "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+    "RUSTSEC-2026-0258", # h2 0.3: unbounded empty DATA frames
 ]


### PR DESCRIPTION
Every CI run fails the `cargo audit` step since 2026-08-17, when RUSTSEC-2026-0258 (h2 0.3: unbounded empty DATA frames) was published. All PRs currently show a red X regardless of their contents.

h2 0.3.27 enters the lockfile through the same legacy aws chain as the existing rustls-webpki ignores: `dial9-tokio-telemetry` -> `aws-sdk-s3-transfer-manager` -> `aws-config` -> `aws-smithy-http-client`, which still uses hyper 0.14. The advisory's only fix is h2 >= 0.4.16 and no 0.3.x patch exists, so this can't be resolved from this workspace's manifests — same situation as the three rustls-webpki ignores already in `.cargo/audit.toml`, and the same removal condition applies (the upstream aws-s3-transfer-manager-rs migration off the legacy chain).

Exploitability in this position is limited: the advisory needs a malicious HTTP/2 peer, and in this chain h2 0.3 only acts as a TLS client to AWS endpoints.

Verified locally with CI's exact steps: `cargo generate-lockfile --ignore-rust-version && cargo audit` fails before this change and exits 0 after, with the same 4 allowed warnings as before.