### PR TITLE
proxy_cache: reject zero-length and unsatisfiable suffix byte ranges (RFC 9110 §14.1.2)

### DIFF
--- a/pingora-proxy/src/proxy_cache.rs
+++ b/pingora-proxy/src/proxy_cache.rs
@@ -1153,6 +1153,10 @@ pub mod range_filter {
                     continue;
                 }
             };
+            if range.start >= range.end {
+                // Skip zero-length or unsatisfiable range specifications per RFC 9110 §14.1.2
+                continue;
+            }
             // For now we stick to non-overlapping, ascending ranges for simplicity
             // and parity with nginx
             if range.start < last_range_end {
@@ -1214,6 +1218,11 @@ pub mod range_filter {
             parse_range_header(b"bytes=-12", 10, None),
             RangeType::new_single(0, 10)
         );
+        assert_eq!(
+            parse_range_header(b"bytes=-0", 10, None),
+            RangeType::Invalid
+        );
+        assert_eq!(parse_range_header(b"bytes=-5", 0, None), RangeType::Invalid);
         assert_eq!(parse_range_header(b"bytes=-", 10, None), RangeType::Invalid);
         assert_eq!(parse_range_header(b"bytes=", 10, None), RangeType::Invalid);
         assert_eq!(
@@ -1647,6 +1656,26 @@ pub mod range_filter {
         assert!(resp.headers.get("accept-ranges").is_none());
         assert!(resp.headers.get("content-encoding").is_none());
         assert!(resp.headers.get("transfer-encoding").is_none());
+    }
+
+    #[test]
+    fn test_range_filter_zero_length_suffix() {
+        let req = RequestHeader::build(http::Method::GET, b"/", Some(1)).unwrap();
+        let mut req_range = req.clone();
+        req_range.insert_header("Range", "bytes=-5").unwrap();
+
+        // 0-byte resource with 200 OK
+        let mut resp = ResponseHeader::build(200, Some(1)).unwrap();
+        resp.append_header("Content-Length", "0").unwrap();
+
+        let range_type = range_header_filter(&req_range, &mut resp, None);
+        assert_eq!(RangeType::Invalid, range_type);
+        assert_eq!(resp.status.as_u16(), 416);
+        assert_eq!(resp.headers.get("content-length").unwrap().as_bytes(), b"0");
+        assert_eq!(
+            resp.headers.get("content-range").unwrap().as_bytes(),
+            b"bytes */0"
+        );
     }
 
     // Multipart Tests


### PR DESCRIPTION
### Summary
Fixes an issue where suffix byte range requests on zero-length representations (`Range: bytes=-5` on `Content-Length: 0`) or zero-length suffix requests (`Range: bytes=-0`) were evaluated as satisfiable ranges (`0..0` or `10..10`).

### Details & RFC Conformance
Per [RFC 9110 Section 14.1.2](https://www.rfc-editor.org/rfc/rfc9110#section-14.1.2):
> *"A suffix-byte-range-spec is unsatisfiable if the suffix-length is zero, or if the representation has a length of zero."*

Previously:
1. `Range: bytes=-5` on a 0-byte representation evaluated to `0..0`, causing `range_header_filter` to format `r.end - 1` (`0usize - 1usize`), emitting `Content-Range: bytes 0-18446744073709551615/0`.
2. For multipart range requests on 0-byte representations (e.g. `Range: bytes=-2,-5`), the underflow inflated `calculate_multipart_length` to declare `Content-Length: 246` while delivering 0 payload bytes.
3. `Range: bytes=-0` on a 10-byte resource evaluated to `10..10`, emitting `Content-Range: bytes 10-9/10`.

### Solution
Inside `parse_range_header`, skip ranges where `range.start >= range.end`. When all specified ranges are unsatisfiable or skipped, `ranges.is_empty()` returns `RangeType::Invalid`, allowing Pingora to return `416 Range Not Satisfiable` with `Content-Range: bytes */{length}` as required by RFC 9110.

### Tests
- Added unit tests covering `bytes=-0` on a 10-byte resource and `bytes=-5` on a 0-byte resource in `test_parse_range`.
- Added end-to-end filter test `test_range_filter_zero_length_suffix` asserting `416 Range Not Satisfiable` with `Content-Range: bytes */0`.
