### PR TITLE
timeout: prevent lost wakeup in TimerStub::poll

### DIFF
--- a/pingora-timeout/src/timer.rs
+++ b/pingora-timeout/src/timer.rs
@@ -72,10 +72,30 @@ pub struct TimerStub(Arc<Notify>, Arc<AtomicBool>);
 impl TimerStub {
     /// Wait for the timer to expire.
     pub async fn poll(self) {
+        self.poll_impl(|| {}).await;
+    }
+
+    // The hook makes the check-to-registration window deterministic in tests.
+    async fn poll_impl<F>(self, before_waiter: F)
+    where
+        F: FnOnce(),
+    {
         if self.1.load(Ordering::SeqCst) {
             return;
         }
-        self.0.notified().await;
+
+        // Register the waiter before checking the flag again. `notify_waiters`
+        // does not retain a permit for waiters created after the notification.
+        before_waiter();
+        let notified = self.0.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if self.1.load(Ordering::SeqCst) {
+            return;
+        }
+
+        notified.await;
     }
 }
 
@@ -323,5 +343,17 @@ mod tests {
         tm.unpause();
         t1.poll().await;
         assert_eq!(now.elapsed().as_secs(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_timer_stub_poll_does_not_miss_fire() {
+        let timer = Timer::new();
+        let stub = timer.subscribe();
+
+        // Fire after the first flag check but before the waiter is registered.
+        // The second check must observe the fire instead of sleeping forever.
+        tokio::time::timeout(Duration::from_secs(1), stub.poll_impl(|| timer.fire()))
+            .await
+            .expect("TimerStub::poll missed a fire");
     }
 }


### PR DESCRIPTION
## Summary

`TimerStub::poll()` could miss a timer notification if `Timer::fire()` ran after the initial fired flag check but before the waiter was registered.

`Notify::notify_waiters()` does not retain a permit for future waiters, so the poll could remain pending indefinitely.

This change:

- registers and enables the `Notified` waiter before rechecking the fired flag;
- returns immediately when the timer fires during that registration window;
- adds a deterministic regression test covering the lost-wakeup race.

Tested by the following cmd:

- `cargo test -p pingora-timeout`
- `cargo clippy -p pingora-timeout --all-targets -- -D warnings`