### PR TITLE
ci: audit dependency changes on main

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,7 +3,7 @@ name: Security Audit
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "**/Cargo.toml"
   schedule:


### PR DESCRIPTION
The security audit workflow filters push events to the nonexistent `master` branch, so `Cargo.toml` changes on `main` do not trigger an audit.

Update the branch filter to `main`. Scheduled audits remain unchanged.

Fixes #984