### PR TITLE
fix(proxy): return 504 for upstream timeouts in fail_to_proxy per RFC 9110

### DIFF
--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -626,24 +626,7 @@ pub trait ProxyHttp {
     where
         Self::CTX: Send + Sync,
     {
-        let code = match e.etype() {
-            HTTPStatus(code) => *code,
-            _ => {
-                match e.esource() {
-                    ErrorSource::Upstream => 502,
-                    ErrorSource::Downstream => {
-                        match e.etype() {
-                            WriteError | ReadError | ConnectionClosed => {
-                                /* conn already dead */
-                                0
-                            }
-                            _ => 400,
-                        }
-                    }
-                    ErrorSource::Internal | ErrorSource::Unset => 500,
-                }
-            }
-        };
+        let code = default_fail_to_proxy_status(e);
         if code > 0 {
             session.respond_error(code).await.unwrap_or_else(|e| {
                 error!("failed to send error response to downstream: {e}");
@@ -733,4 +716,64 @@ pub trait ProxyHttp {
 pub struct FailToProxy {
     pub error_code: u16,
     pub can_reuse_downstream: bool,
+}
+
+/// Helper function to determine the default HTTP status code for a proxy error.
+///
+/// Maps upstream timeouts ([`ConnectTimedout`], [`TLSHandshakeTimedout`], [`ReadTimedout`],
+/// [`WriteTimedout`]) to `504 Gateway Timeout` per RFC 9110 §15.6.6. Other upstream errors map to
+/// `502 Bad Gateway`. Client write/read errors map to `0` (connection already dead) or `400 Bad Request`.
+/// Internal errors map to `500 Internal Server Error`.
+pub fn default_fail_to_proxy_status(e: &Error) -> u16 {
+    match e.etype() {
+        HTTPStatus(code) => *code,
+        _ => match e.esource() {
+            ErrorSource::Upstream => match e.etype() {
+                ConnectTimedout | TLSHandshakeTimedout | ReadTimedout | WriteTimedout => 504,
+                _ => 502,
+            },
+            ErrorSource::Downstream => match e.etype() {
+                WriteError | ReadError | ConnectionClosed => {
+                    /* conn already dead */
+                    0
+                }
+                _ => 400,
+            },
+            ErrorSource::Internal | ErrorSource::Unset => 500,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_fail_to_proxy_status() {
+        // Upstream timeouts -> 504 Gateway Timeout (RFC 9110 §15.6.6)
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ConnectTimedout)), 504);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(TLSHandshakeTimedout)), 504);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ReadTimedout)), 504);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(WriteTimedout)), 504);
+
+        // Other upstream errors -> 502 Bad Gateway
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ConnectRefused)), 502);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ConnectNoRoute)), 502);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(InvalidH2)), 502);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_up(InvalidCert)), 502);
+
+        // Downstream errors
+        assert_eq!(default_fail_to_proxy_status(&Error::new_down(WriteError)), 0);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_down(ReadError)), 0);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_down(ConnectionClosed)), 0);
+        assert_eq!(default_fail_to_proxy_status(&Error::new_down(InvalidHTTPHeader)), 400);
+
+        // Internal and unset errors -> 500
+        assert_eq!(default_fail_to_proxy_status(&Error::new_in(InternalError)), 500);
+        assert_eq!(default_fail_to_proxy_status(&Error::new(InternalError)), 500);
+
+        // Explicit HTTPStatus preservation
+        assert_eq!(default_fail_to_proxy_status(&Error::new(HTTPStatus(403))), 403);
+        assert_eq!(default_fail_to_proxy_status(&Error::new(HTTPStatus(429))), 429);
+    }
 }

--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -751,29 +751,71 @@ mod tests {
     #[test]
     fn test_default_fail_to_proxy_status() {
         // Upstream timeouts -> 504 Gateway Timeout (RFC 9110 §15.6.6)
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ConnectTimedout)), 504);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(TLSHandshakeTimedout)), 504);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ReadTimedout)), 504);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(WriteTimedout)), 504);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(ConnectTimedout)),
+            504
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(TLSHandshakeTimedout)),
+            504
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(ReadTimedout)),
+            504
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(WriteTimedout)),
+            504
+        );
 
         // Other upstream errors -> 502 Bad Gateway
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ConnectRefused)), 502);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(ConnectNoRoute)), 502);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(ConnectRefused)),
+            502
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(ConnectNoRoute)),
+            502
+        );
         assert_eq!(default_fail_to_proxy_status(&Error::new_up(InvalidH2)), 502);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_up(InvalidCert)), 502);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_up(InvalidCert)),
+            502
+        );
 
         // Downstream errors
-        assert_eq!(default_fail_to_proxy_status(&Error::new_down(WriteError)), 0);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_down(WriteError)),
+            0
+        );
         assert_eq!(default_fail_to_proxy_status(&Error::new_down(ReadError)), 0);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_down(ConnectionClosed)), 0);
-        assert_eq!(default_fail_to_proxy_status(&Error::new_down(InvalidHTTPHeader)), 400);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_down(ConnectionClosed)),
+            0
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_down(InvalidHTTPHeader)),
+            400
+        );
 
         // Internal and unset errors -> 500
-        assert_eq!(default_fail_to_proxy_status(&Error::new_in(InternalError)), 500);
-        assert_eq!(default_fail_to_proxy_status(&Error::new(InternalError)), 500);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new_in(InternalError)),
+            500
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new(InternalError)),
+            500
+        );
 
         // Explicit HTTPStatus preservation
-        assert_eq!(default_fail_to_proxy_status(&Error::new(HTTPStatus(403))), 403);
-        assert_eq!(default_fail_to_proxy_status(&Error::new(HTTPStatus(429))), 429);
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new(HTTPStatus(403))),
+            403
+        );
+        assert_eq!(
+            default_fail_to_proxy_status(&Error::new(HTTPStatus(429))),
+            429
+        );
     }
 }


### PR DESCRIPTION
Fixes #980

### Problem

In `pingora-proxy/src/proxy_trait.rs`, `fail_to_proxy` currently maps all upstream-sourced errors to `502 Bad Gateway`:

```rust
ErrorSource::Upstream => 502,
```

Consequently, upstream deadline expiries (`ConnectTimedout`, `TLSHandshakeTimedout`, `ReadTimedout`, `WriteTimedout`) surface to downstream clients as `502 Bad Gateway`.

Per [RFC 9110 §15.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.6.6):
> *"The 504 (Gateway Timeout) status code indicates that the server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request."*

Both NGINX and Envoy map upstream connection, read, and write deadline expiries to 504. In Pingora, returning 502 prevents monitoring and clients from distinguishing between slow/hung upstreams and broken/refused upstreams.

### Solution

1. **Extract `default_fail_to_proxy_status(e: &Error) -> u16`**:
   Extracts the default status mapping into a public helper function so custom proxy implementations can reuse the standard mapping without copying the whole match structure.
2. **RFC 9110-compliant 504 Mapping**:
   - Upstream deadline expiries (`ConnectTimedout`, `TLSHandshakeTimedout`, `ReadTimedout`, `WriteTimedout`) now map to `504 Gateway Timeout`.
   - All other upstream failures (connection refused, no route, invalid certificates, broken frames) continue to return `502 Bad Gateway`.
   - Downstream and internal status mappings remain completely unchanged.
3. **Unit Tests**:
   Added unit tests in `proxy_trait.rs` covering all upstream timeout branches, non-timeout upstream failures, downstream disconnections (status 0), and explicit HTTPStatus preservation.
