### PR TITLE
Build pingora-core on illumos and Solaris

### DIFF
--- a/pingora-core/src/listeners/l4.rs
+++ b/pingora-core/src/listeners/l4.rs
@@ -193,11 +193,20 @@ fn apply_tcp_socket_options(sock: &TcpSocket, opt: Option<&TcpSocketOptions>) ->
             .or_err(BindError, "failed to set IPV6_V6ONLY")?;
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(any(target_os = "illumos", target_os = "solaris"))))]
     if let Some(reuseport) = opt.so_reuseport {
         socket_ref
             .set_reuse_port(reuseport)
             .or_err(BindError, "failed to set SO_REUSEPORT")?;
+    }
+
+    // illumos and Solaris have no SO_REUSEPORT; refuse rather than ignore the request.
+    #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+    if opt.so_reuseport.is_some() {
+        return pingora_error::Error::e_explain(
+            BindError,
+            "SO_REUSEPORT is not supported on this platform",
+        );
     }
 
     #[cfg(unix)]

--- a/pingora-core/src/server/daemon.rs
+++ b/pingora-core/src/server/daemon.rs
@@ -420,7 +420,7 @@ fn build_daemonize(conf: &ServerConf) -> Daemonize<()> {
             let group_id = unsafe { gid_for_username(&user_cstr).map(|gid| gid as i32) };
             #[cfg(target_os = "freebsd")]
             let group_id = unsafe { gid_for_username(&user_cstr).map(|gid| gid as u32) };
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "illumos", target_os = "solaris"))]
             let group_id = unsafe { gid_for_username(&user_cstr) };
 
             daemonize


### PR DESCRIPTION
pingora-core does not compile on illumos (x86_64-unknown-illumos):

- `server/daemon.rs` only defines `group_id` for linux, macos and freebsd. On illumos `gid_t` is `u32`, so the linux arm applies.
- `socket2::SockRef::set_reuse_port` does not exist on illumos or Solaris. Instead of skipping the option silently, `so_reuseport` now returns a `BindError` there.

Verified with `cargo check` and `cargo build` natively on SmartOS with the `openssl` and `rustls` features.

🤖 Generated with Claude Code