### PR TITLE
feat(http1): expose configurable request-header parser admission limits (#993)

### DIFF
--- a/pingora-core/src/apps/mod.rs
+++ b/pingora-core/src/apps/mod.rs
@@ -89,6 +89,35 @@ pub struct HttpServerOptions {
     ///
     /// Default: `None`
     pub h2_idle_timeout: Option<Duration>,
+
+    /// Maximum size of HTTP/1 request headers in bytes (including the request line).
+    ///
+    /// When unset, Pingora's default limit of 1,048,575 bytes (~1 MiB) applies.
+    pub max_header_size: Option<usize>,
+
+    /// Maximum number of HTTP/1 request headers allowed.
+    ///
+    /// When unset, Pingora's default limit of 256 headers applies.
+    pub max_headers: Option<usize>,
+}
+
+impl HttpServerOptions {
+    /// Validate that the options are valid.
+    pub fn validate(&self) -> pingora_error::Result<()> {
+        if let Some(0) = self.max_header_size {
+            return pingora_error::Error::e_explain(
+                pingora_error::ErrorType::InvalidHTTPHeader,
+                "max_header_size must be greater than 0",
+            );
+        }
+        if let Some(0) = self.max_headers {
+            return pingora_error::Error::e_explain(
+                pingora_error::ErrorType::InvalidHTTPHeader,
+                "max_headers must be greater than 0",
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Settings persisted across HTTP/1.x keepalive requests on the same downstream connection.
@@ -356,10 +385,18 @@ where
                 self.server_options()
                     .and_then(|opts| opts.keepalive_request_limit),
             );
+            if let Some(opts) = self.server_options() {
+                session.set_max_header_size(opts.max_header_size);
+                session.set_max_headers(opts.max_headers);
+            }
 
             let mut result = self.process_new_http(session, shutdown).await;
             while let Some((stream, persistent_settings)) = result.map(|r| r.consume()) {
                 let mut session = ServerSession::new_http1(stream);
+                if let Some(opts) = self.server_options() {
+                    session.set_max_header_size(opts.max_header_size);
+                    session.set_max_headers(opts.max_headers);
+                }
                 if let Some(persistent_settings) = persistent_settings {
                     persistent_settings.apply_to_session(&mut session);
                 }
@@ -425,5 +462,30 @@ mod tests {
         assert!(session2.take_connection_user_context().is_none());
         // Keepalive should still work
         assert_eq!(session2.get_keepalive(), Some(30));
+    }
+
+    #[test]
+    fn test_http_server_options_validation() {
+        let default_opts = HttpServerOptions::default();
+        assert!(default_opts.validate().is_ok());
+
+        let valid_opts = HttpServerOptions {
+            max_header_size: Some(8192),
+            max_headers: Some(64),
+            ..Default::default()
+        };
+        assert!(valid_opts.validate().is_ok());
+
+        let zero_size_opts = HttpServerOptions {
+            max_header_size: Some(0),
+            ..Default::default()
+        };
+        assert!(zero_size_opts.validate().is_err());
+
+        let zero_headers_opts = HttpServerOptions {
+            max_headers: Some(0),
+            ..Default::default()
+        };
+        assert!(zero_headers_opts.validate().is_err());
     }
 }

--- a/pingora-core/src/apps/mod.rs
+++ b/pingora-core/src/apps/mod.rs
@@ -286,6 +286,13 @@ where
         mut stream: Stream,
         shutdown: &ShutdownWatch,
     ) -> Option<Stream> {
+        if let Some(opts) = self.server_options() {
+            if let Err(e) = opts.validate() {
+                error!("Invalid HttpServerOptions: {e}");
+                return None;
+            }
+        }
+
         let mut h2c = self.server_options().as_ref().map_or(false, |o| o.h2c);
         let custom = self
             .server_options()
@@ -376,16 +383,28 @@ where
                     .and_then(|opts| opts.keepalive_request_limit),
             );
             if let Some(opts) = self.server_options() {
-                let _ = session.set_max_header_size(opts.max_header_size);
-                let _ = session.set_max_headers(opts.max_headers);
+                if let Err(e) = session.set_max_header_size(opts.max_header_size) {
+                    error!("Failed to set max_header_size: {e}");
+                    return None;
+                }
+                if let Err(e) = session.set_max_headers(opts.max_headers) {
+                    error!("Failed to set max_headers: {e}");
+                    return None;
+                }
             }
 
             let mut result = self.process_new_http(session, shutdown).await;
             while let Some((stream, persistent_settings)) = result.map(|r| r.consume()) {
                 let mut session = ServerSession::new_http1(stream);
                 if let Some(opts) = self.server_options() {
-                    let _ = session.set_max_header_size(opts.max_header_size);
-                    let _ = session.set_max_headers(opts.max_headers);
+                    if let Err(e) = session.set_max_header_size(opts.max_header_size) {
+                        error!("Failed to set max_header_size on reused session: {e}");
+                        return None;
+                    }
+                    if let Err(e) = session.set_max_headers(opts.max_headers) {
+                        error!("Failed to set max_headers on reused session: {e}");
+                        return None;
+                    }
                 }
                 if let Some(persistent_settings) = persistent_settings {
                     persistent_settings.apply_to_session(&mut session);
@@ -497,5 +516,57 @@ mod tests {
             ..Default::default()
         };
         assert!(over_max_headers_opts.validate().is_err());
+    }
+
+    struct MockAppWithInvalidOptions {
+        opts: HttpServerOptions,
+    }
+
+    #[async_trait]
+    impl HttpServerApp for MockAppWithInvalidOptions {
+        async fn process_new_http(
+            self: &Arc<Self>,
+            _session: ServerSession,
+            _shutdown: &ShutdownWatch,
+        ) -> Option<ReusedHttpStream> {
+            panic!("Should not be called when options are invalid!");
+        }
+
+        fn server_options(&self) -> Option<&HttpServerOptions> {
+            Some(&self.opts)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fail_closed_activation_with_invalid_server_options() {
+        let (_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        for invalid_opts in [
+            HttpServerOptions {
+                max_header_size: Some(0),
+                ..Default::default()
+            },
+            HttpServerOptions {
+                max_headers: Some(0),
+                ..Default::default()
+            },
+            HttpServerOptions {
+                max_header_size: Some(crate::protocols::http::v1::common::MAX_HEADER_SIZE + 1),
+                ..Default::default()
+            },
+            HttpServerOptions {
+                max_headers: Some(crate::protocols::http::v1::common::MAX_HEADERS + 1),
+                ..Default::default()
+            },
+        ] {
+            let app = Arc::new(MockAppWithInvalidOptions { opts: invalid_opts });
+            let mock_io = Builder::new().build();
+            let stream = Box::new(mock_io);
+            let res = app.process_new(stream, &shutdown_rx).await;
+            assert!(
+                res.is_none(),
+                "Must fail closed (return None) when server options are invalid"
+            );
+        }
     }
 }

--- a/pingora-core/src/apps/mod.rs
+++ b/pingora-core/src/apps/mod.rs
@@ -104,18 +104,8 @@ pub struct HttpServerOptions {
 impl HttpServerOptions {
     /// Validate that the options are valid.
     pub fn validate(&self) -> pingora_error::Result<()> {
-        if let Some(0) = self.max_header_size {
-            return pingora_error::Error::e_explain(
-                pingora_error::ErrorType::InvalidHTTPHeader,
-                "max_header_size must be greater than 0",
-            );
-        }
-        if let Some(0) = self.max_headers {
-            return pingora_error::Error::e_explain(
-                pingora_error::ErrorType::InvalidHTTPHeader,
-                "max_headers must be greater than 0",
-            );
-        }
+        crate::protocols::http::v1::common::validate_max_header_size(self.max_header_size)?;
+        crate::protocols::http::v1::common::validate_max_headers(self.max_headers)?;
         Ok(())
     }
 }
@@ -386,16 +376,16 @@ where
                     .and_then(|opts| opts.keepalive_request_limit),
             );
             if let Some(opts) = self.server_options() {
-                session.set_max_header_size(opts.max_header_size);
-                session.set_max_headers(opts.max_headers);
+                let _ = session.set_max_header_size(opts.max_header_size);
+                let _ = session.set_max_headers(opts.max_headers);
             }
 
             let mut result = self.process_new_http(session, shutdown).await;
             while let Some((stream, persistent_settings)) = result.map(|r| r.consume()) {
                 let mut session = ServerSession::new_http1(stream);
                 if let Some(opts) = self.server_options() {
-                    session.set_max_header_size(opts.max_header_size);
-                    session.set_max_headers(opts.max_headers);
+                    let _ = session.set_max_header_size(opts.max_header_size);
+                    let _ = session.set_max_headers(opts.max_headers);
                 }
                 if let Some(persistent_settings) = persistent_settings {
                     persistent_settings.apply_to_session(&mut session);
@@ -487,5 +477,25 @@ mod tests {
             ..Default::default()
         };
         assert!(zero_headers_opts.validate().is_err());
+
+        // Test upper bounds
+        let max_size_opts = HttpServerOptions {
+            max_header_size: Some(crate::protocols::http::v1::common::MAX_HEADER_SIZE),
+            max_headers: Some(crate::protocols::http::v1::common::MAX_HEADERS),
+            ..Default::default()
+        };
+        assert!(max_size_opts.validate().is_ok());
+
+        let over_max_size_opts = HttpServerOptions {
+            max_header_size: Some(crate::protocols::http::v1::common::MAX_HEADER_SIZE + 1),
+            ..Default::default()
+        };
+        assert!(over_max_size_opts.validate().is_err());
+
+        let over_max_headers_opts = HttpServerOptions {
+            max_headers: Some(crate::protocols::http::v1::common::MAX_HEADERS + 1),
+            ..Default::default()
+        };
+        assert!(over_max_headers_opts.validate().is_err());
     }
 }

--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -374,10 +374,14 @@ impl Session {
 
     /// Set the maximum size of request headers (in bytes) allowed for HTTP/1.x downstream sessions.
     ///
-    /// Only applicable for HTTP/1.x connections; noop for h2, subrequest, and custom sessions.
-    pub fn set_max_header_size(&mut self, max: Option<usize>) {
+    /// When set to `None`, Pingora's default limit of 1,048,575 bytes (~1 MiB) applies.
+    /// Returns an error if `max` is `Some(0)` or exceeds `MAX_HEADER_SIZE`.
+    /// For non-HTTP/1.x connections (h2, subrequest, custom), validates the bounds and returns `Ok(())`.
+    pub fn set_max_header_size(&mut self, max: Option<usize>) -> Result<()> {
         if let Self::H1(s) = self {
-            s.set_max_header_size(max);
+            s.set_max_header_size(max)
+        } else {
+            crate::protocols::http::v1::common::validate_max_header_size(max)
         }
     }
 
@@ -391,10 +395,14 @@ impl Session {
 
     /// Set the maximum number of request headers allowed for HTTP/1.x downstream sessions.
     ///
-    /// Only applicable for HTTP/1.x connections; noop for h2, subrequest, and custom sessions.
-    pub fn set_max_headers(&mut self, max: Option<usize>) {
+    /// When set to `None`, Pingora's default limit of 256 headers applies.
+    /// Returns an error if `max` is `Some(0)` or exceeds `MAX_HEADERS`.
+    /// For non-HTTP/1.x connections (h2, subrequest, custom), validates the bounds and returns `Ok(())`.
+    pub fn set_max_headers(&mut self, max: Option<usize>) -> Result<()> {
         if let Self::H1(s) = self {
-            s.set_max_headers(max);
+            s.set_max_headers(max)
+        } else {
+            crate::protocols::http::v1::common::validate_max_headers(max)
         }
     }
 
@@ -1314,5 +1322,40 @@ mod tests {
         ) -> Result<()> {
             unreachable!("not used by proxy task dispatch test")
         }
+    }
+
+    #[tokio::test]
+    async fn test_server_session_header_limits_bounds() {
+        use crate::protocols::http::v1::common::{MAX_HEADERS, MAX_HEADER_SIZE};
+        use tokio_test::io::Builder;
+
+        let mock_io = Builder::new().build();
+        let mut session = Session::new_http1(Box::new(mock_io));
+
+        // Valid bounds
+        assert!(session.set_max_header_size(Some(MAX_HEADER_SIZE)).is_ok());
+        assert_eq!(session.max_header_size(), Some(MAX_HEADER_SIZE));
+        assert!(session.set_max_header_size(Some(1)).is_ok());
+        assert_eq!(session.max_header_size(), Some(1));
+        assert!(session.set_max_header_size(None).is_ok());
+        assert_eq!(session.max_header_size(), None);
+
+        // Invalid bounds
+        assert!(session.set_max_header_size(Some(0)).is_err());
+        assert!(session
+            .set_max_header_size(Some(MAX_HEADER_SIZE + 1))
+            .is_err());
+
+        // Header count bounds
+        assert!(session.set_max_headers(Some(MAX_HEADERS)).is_ok());
+        assert_eq!(session.max_headers(), Some(MAX_HEADERS));
+        assert!(session.set_max_headers(Some(1)).is_ok());
+        assert_eq!(session.max_headers(), Some(1));
+        assert!(session.set_max_headers(None).is_ok());
+        assert_eq!(session.max_headers(), None);
+
+        // Invalid header counts
+        assert!(session.set_max_headers(Some(0)).is_err());
+        assert!(session.set_max_headers(Some(MAX_HEADERS + 1)).is_err());
     }
 }

--- a/pingora-core/src/protocols/http/server.rs
+++ b/pingora-core/src/protocols/http/server.rs
@@ -372,6 +372,40 @@ impl Session {
         }
     }
 
+    /// Set the maximum size of request headers (in bytes) allowed for HTTP/1.x downstream sessions.
+    ///
+    /// Only applicable for HTTP/1.x connections; noop for h2, subrequest, and custom sessions.
+    pub fn set_max_header_size(&mut self, max: Option<usize>) {
+        if let Self::H1(s) = self {
+            s.set_max_header_size(max);
+        }
+    }
+
+    /// Return the configured maximum size of HTTP/1 request headers, if set.
+    pub fn max_header_size(&self) -> Option<usize> {
+        match self {
+            Self::H1(s) => s.max_header_size(),
+            _ => None,
+        }
+    }
+
+    /// Set the maximum number of request headers allowed for HTTP/1.x downstream sessions.
+    ///
+    /// Only applicable for HTTP/1.x connections; noop for h2, subrequest, and custom sessions.
+    pub fn set_max_headers(&mut self, max: Option<usize>) {
+        if let Self::H1(s) = self {
+            s.set_max_headers(max);
+        }
+    }
+
+    /// Return the configured maximum number of HTTP/1 request headers, if set.
+    pub fn max_headers(&self) -> Option<usize> {
+        match self {
+            Self::H1(s) => s.max_headers(),
+            _ => None,
+        }
+    }
+
     /// Sets the downstream read timeout. This will trigger if we're unable
     /// to read from the stream after `timeout`.
     ///

--- a/pingora-core/src/protocols/http/v1/common.rs
+++ b/pingora-core/src/protocols/http/v1/common.rs
@@ -24,10 +24,46 @@ use std::time::Duration;
 use super::body::BodyWriter;
 use crate::utils::KVRef;
 
-pub(super) const MAX_HEADERS: usize = 256;
+pub const MAX_HEADERS: usize = 256;
 
 pub(super) const INIT_HEADER_BUF_SIZE: usize = 4096;
-pub(super) const MAX_HEADER_SIZE: usize = 1048575;
+pub const MAX_HEADER_SIZE: usize = 1048575;
+
+/// Validate an optional maximum header size.
+///
+/// Must be non-zero and at most `MAX_HEADER_SIZE`.
+pub fn validate_max_header_size(max: Option<usize>) -> Result<()> {
+    if let Some(s) = max {
+        if s == 0 {
+            return Error::e_explain(InvalidHTTPHeader, "max_header_size must be greater than 0");
+        }
+        if s > MAX_HEADER_SIZE {
+            return Error::e_explain(
+                InvalidHTTPHeader,
+                format!("max_header_size must be at most {MAX_HEADER_SIZE}"),
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Validate an optional maximum header count.
+///
+/// Must be non-zero and at most `MAX_HEADERS`.
+pub fn validate_max_headers(max: Option<usize>) -> Result<()> {
+    if let Some(h) = max {
+        if h == 0 {
+            return Error::e_explain(InvalidHTTPHeader, "max_headers must be greater than 0");
+        }
+        if h > MAX_HEADERS {
+            return Error::e_explain(
+                InvalidHTTPHeader,
+                format!("max_headers must be at most {MAX_HEADERS}"),
+            );
+        }
+    }
+    Ok(())
+}
 
 pub(crate) const BODY_BUF_LIMIT: usize = 1024 * 64;
 

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -310,10 +310,10 @@ impl HttpSession {
         let mut skip_next_read = already_read != 0;
         let mut detached_suffix = None;
         loop {
-            if already_read > max_header_size {
-                /* NOTE: this check only blocks second read. The first large read is allowed
-                since the buf is already allocated. The goal is to avoid slowly bloating
-                this buffer */
+            if !skip_next_read && already_read > max_header_size {
+                /* NOTE: this check only blocks subsequent reads. The first read is allowed
+                since the buf is already allocated or pre-filled. The goal is to avoid slowly
+                bloating this buffer when an incomplete header exceeds limits. */
                 return Error::e_explain(
                     InvalidHTTPHeader,
                     format!("Request header larger than {max_header_size}"),
@@ -442,6 +442,12 @@ impl HttpSession {
                         return Ok(Some(s));
                     }
                     HeaderParseState::Partial => {
+                        if buf.len() > max_header_size {
+                            return Error::e_explain(
+                                InvalidHTTPHeader,
+                                format!("Request header larger than {max_header_size}"),
+                            );
+                        }
                         break; /* continue the read loop */
                     }
                     HeaderParseState::Invalid(e) => match e {
@@ -761,8 +767,11 @@ impl HttpSession {
     /// Set the maximum size of HTTP/1 request headers (including request line) in bytes.
     ///
     /// When set to `None`, Pingora's default limit of 1,048,575 bytes (~1 MiB) applies.
-    pub fn set_max_header_size(&mut self, max: Option<usize>) {
+    /// Returns an error if `max` is `Some(0)` or exceeds `MAX_HEADER_SIZE`.
+    pub fn set_max_header_size(&mut self, max: Option<usize>) -> Result<()> {
+        validate_max_header_size(max)?;
         self.max_header_size = max;
+        Ok(())
     }
 
     /// Return the configured maximum size of HTTP/1 request headers, if set.
@@ -773,8 +782,11 @@ impl HttpSession {
     /// Set the maximum number of HTTP/1 request headers allowed.
     ///
     /// When set to `None`, Pingora's default limit of 256 headers applies.
-    pub fn set_max_headers(&mut self, max: Option<usize>) {
+    /// Returns an error if `max` is `Some(0)` or exceeds `MAX_HEADERS`.
+    pub fn set_max_headers(&mut self, max: Option<usize>) -> Result<()> {
+        validate_max_headers(max)?;
         self.max_headers = max;
+        Ok(())
     }
 
     /// Return the configured maximum number of HTTP/1 request headers, if set.
@@ -4575,7 +4587,7 @@ mod test_pipelining {
         let input = b"GET /hello HTTP/1.1\r\nHost: example.com\r\nX-Foo: Bar\r\n\r\n";
         let mock_io = Builder::new().read(&input[..]).build();
         let mut session = HttpSession::new(Box::new(mock_io));
-        session.set_max_header_size(Some(512));
+        session.set_max_header_size(Some(512)).unwrap();
         assert_eq!(session.max_header_size(), Some(512));
 
         let res = session.read_request().await;
@@ -4591,7 +4603,7 @@ mod test_pipelining {
         let chunk2 = b"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz\r\n\r\n";
         let mock_io = Builder::new().read(&chunk1[..]).read(&chunk2[..]).build();
         let mut session = HttpSession::new(Box::new(mock_io));
-        session.set_max_header_size(Some(100));
+        session.set_max_header_size(Some(100)).unwrap();
 
         let res = session.read_request().await;
         assert!(res.is_err());
@@ -4610,7 +4622,7 @@ mod test_pipelining {
         assert_eq!(input.len(), 101);
         let mock_io = Builder::new().read(&input[..]).build();
         let mut session = HttpSession::new(Box::new(mock_io));
-        session.set_max_header_size(Some(100));
+        session.set_max_header_size(Some(100)).unwrap();
 
         let res = session.read_request().await;
         assert!(res.is_err());
@@ -4629,11 +4641,77 @@ mod test_pipelining {
 
         let mock_io = Builder::new().build();
         let mut session = HttpSession::new(Box::new(mock_io));
-        session.set_max_header_size(Some(50));
+        session.set_max_header_size(Some(50)).unwrap();
         session.set_pipelined_prefix(prefix);
 
         let res = session.read_request().await;
         assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_pipelined_prefix_with_large_suffix() {
+        init_log();
+        // Positive test: Header is 42 bytes, well within the limit of 100 bytes.
+        // Pipelined prefix contains header + 500 bytes of body / following data (total 542 bytes).
+        // Must be accepted, and the 500-byte suffix preserved.
+        let header = b"GET /first HTTP/1.1\r\nHost: pingora.org\r\n\r\n";
+        assert_eq!(header.len(), 42);
+        let suffix = [b'x'; 500];
+        let mut prefix = BytesMut::with_capacity(header.len() + suffix.len());
+        prefix.extend_from_slice(header);
+        prefix.extend_from_slice(&suffix);
+
+        let mock_io = Builder::new().build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_pipelining_enabled(true);
+        session.set_max_header_size(Some(100)).unwrap();
+        session.set_pipelined_prefix(prefix);
+
+        let res = session.read_request().await;
+        assert!(
+            res.is_ok(),
+            "within-limit header must be accepted despite large pipelined suffix"
+        );
+        assert_eq!(res.unwrap(), Some(header.len()));
+        assert_eq!(session.req_header().uri.path(), "/first");
+
+        // Verify the 500-byte suffix was preserved and not lost
+        let reused = session.reuse().await.unwrap().expect("connection reusable");
+        let (_, next_prefix) = reused.into_parts();
+        let next_prefix = next_prefix.expect("suffix remains buffered");
+        assert_eq!(next_prefix.as_ref(), &suffix[..]);
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_pipelined_prefix_over_limit_header() {
+        init_log();
+        // Negative test: Header itself is 150 bytes, exceeding limit of 100 bytes.
+        // Followed by 200 bytes of body/suffix (total 350 bytes).
+        let mut header = Vec::from(&b"GET / HTTP/1.1\r\nHost: pingora.org\r\nX-Long: "[..]);
+        header.resize(146, b'a');
+        header.extend_from_slice(b"\r\n\r\n");
+        assert_eq!(header.len(), 150);
+
+        let suffix = [b'y'; 200];
+        let mut prefix = BytesMut::with_capacity(header.len() + suffix.len());
+        prefix.extend_from_slice(&header);
+        prefix.extend_from_slice(&suffix);
+
+        let mock_io = Builder::new().build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_pipelining_enabled(true);
+        session.set_max_header_size(Some(100)).unwrap();
+        session.set_pipelined_prefix(prefix);
+
+        let res = session.read_request().await;
+        assert!(
+            res.is_err(),
+            "genuinely over-limit header in pipelined prefix must be rejected"
+        );
         assert_eq!(
             res.unwrap_err().etype(),
             &pingora_error::ErrorType::InvalidHTTPHeader
@@ -4646,7 +4724,7 @@ mod test_pipelining {
         let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nH1: 1\r\nH2: 2\r\nH3: 3\r\n\r\n";
         let mock_io = Builder::new().read(&input[..]).build();
         let mut session = HttpSession::new(Box::new(mock_io));
-        session.set_max_headers(Some(10));
+        session.set_max_headers(Some(10)).unwrap();
         assert_eq!(session.max_headers(), Some(10));
 
         let res = session.read_request().await;
@@ -4661,7 +4739,7 @@ mod test_pipelining {
         let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nH1: 1\r\nH2: 2\r\nH3: 3\r\nH4: 4\r\nH5: 5\r\n\r\n";
         let mock_io = Builder::new().read(&input[..]).build();
         let mut session = HttpSession::new(Box::new(mock_io));
-        session.set_max_headers(Some(3));
+        session.set_max_headers(Some(3)).unwrap();
 
         let res = session.read_request().await;
         assert!(res.is_err());
@@ -4669,6 +4747,34 @@ mod test_pipelining {
             res.unwrap_err().etype(),
             &pingora_error::ErrorType::InvalidHTTPHeader
         );
+    }
+
+    #[test]
+    fn test_direct_setters_bounds_validation() {
+        let mock_io = Builder::new().build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+
+        // max_header_size bounds
+        assert!(session.set_max_header_size(Some(0)).is_err());
+        assert!(session
+            .set_max_header_size(Some(MAX_HEADER_SIZE + 1))
+            .is_err());
+        assert!(session.set_max_header_size(Some(MAX_HEADER_SIZE)).is_ok());
+        assert_eq!(session.max_header_size(), Some(MAX_HEADER_SIZE));
+        assert!(session.set_max_header_size(Some(1)).is_ok());
+        assert_eq!(session.max_header_size(), Some(1));
+        assert!(session.set_max_header_size(None).is_ok());
+        assert_eq!(session.max_header_size(), None);
+
+        // max_headers bounds
+        assert!(session.set_max_headers(Some(0)).is_err());
+        assert!(session.set_max_headers(Some(MAX_HEADERS + 1)).is_err());
+        assert!(session.set_max_headers(Some(MAX_HEADERS)).is_ok());
+        assert_eq!(session.max_headers(), Some(MAX_HEADERS));
+        assert!(session.set_max_headers(Some(1)).is_ok());
+        assert_eq!(session.max_headers(), Some(1));
+        assert!(session.set_max_headers(None).is_ok());
+        assert_eq!(session.max_headers(), None);
     }
 
     #[tokio::test]

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -155,6 +155,8 @@ pub struct HttpSession {
     /// [`super::super::HttpPersistentSettings`] into the next session.
     /// Scoped narrowly so it cannot affect FIN / `abort_on_close` semantics.
     pipelined_idle_bytes_stashed: bool,
+    max_header_size: Option<usize>,
+    max_headers: Option<usize>,
 }
 
 impl HttpSession {
@@ -203,6 +205,8 @@ impl HttpSession {
             pipelining_enabled: false,
             pipelined_prefix: None,
             pipelined_idle_bytes_stashed: false,
+            max_header_size: None,
+            max_headers: None,
         }
     }
 
@@ -286,6 +290,10 @@ impl HttpSession {
             tokio::task::consume_budget().await;
         }
 
+        let max_header_size = self.max_header_size.unwrap_or(MAX_HEADER_SIZE);
+        let max_headers = self.max_headers.unwrap_or(MAX_HEADERS).min(MAX_HEADERS);
+        let init_buf_size = INIT_HEADER_BUF_SIZE.min(max_header_size);
+
         // If the caller (e.g. the proxy layer completing a pipelined request on
         // a reused keep-alive connection) handed us bytes that were read past
         // the end of the previous request's body, pre-fill our parse buffer so
@@ -297,18 +305,18 @@ impl HttpSession {
             .pipelined_prefix
             .take()
             .filter(|prefix| !prefix.is_empty())
-            .unwrap_or_else(|| BytesMut::with_capacity(INIT_HEADER_BUF_SIZE));
+            .unwrap_or_else(|| BytesMut::with_capacity(init_buf_size));
         let mut already_read = buf.len();
         let mut skip_next_read = already_read != 0;
         let mut detached_suffix = None;
         loop {
-            if already_read > MAX_HEADER_SIZE {
+            if already_read > max_header_size {
                 /* NOTE: this check only blocks second read. The first large read is allowed
                 since the buf is already allocated. The goal is to avoid slowly bloating
                 this buffer */
                 return Error::e_explain(
                     InvalidHTTPHeader,
-                    format!("Request header larger than {MAX_HEADER_SIZE}"),
+                    format!("Request header larger than {max_header_size}"),
                 );
             }
 
@@ -329,10 +337,16 @@ impl HttpSession {
             // Use loop as GOTO to retry escaped request buffer, not a real loop
             loop {
                 let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
-                let mut req = httparse::Request::new(&mut headers);
+                let mut req = httparse::Request::new(&mut headers[..max_headers]);
                 let parsed = parse_req_buffer(&mut req, &buf);
                 match parsed {
                     HeaderParseState::Complete(s) => {
+                        if s > max_header_size {
+                            return Error::e_explain(
+                                InvalidHTTPHeader,
+                                format!("Request header larger than {max_header_size}"),
+                            );
+                        }
                         self.raw_header = Some(BufRef(0, s));
 
                         // We have the header name and values we parsed to be just 0 copy Bytes
@@ -742,6 +756,30 @@ impl HttpSession {
     /// persisted by the previous request.
     pub fn take_connection_user_context(&mut self) -> Option<Box<dyn Any + Send + Sync>> {
         self.connection_user_context.take()
+    }
+
+    /// Set the maximum size of HTTP/1 request headers (including request line) in bytes.
+    ///
+    /// When set to `None`, Pingora's default limit of 1,048,575 bytes (~1 MiB) applies.
+    pub fn set_max_header_size(&mut self, max: Option<usize>) {
+        self.max_header_size = max;
+    }
+
+    /// Return the configured maximum size of HTTP/1 request headers, if set.
+    pub fn max_header_size(&self) -> Option<usize> {
+        self.max_header_size
+    }
+
+    /// Set the maximum number of HTTP/1 request headers allowed.
+    ///
+    /// When set to `None`, Pingora's default limit of 256 headers applies.
+    pub fn set_max_headers(&mut self, max: Option<usize>) {
+        self.max_headers = max;
+    }
+
+    /// Return the configured maximum number of HTTP/1 request headers, if set.
+    pub fn max_headers(&self) -> Option<usize> {
+        self.max_headers
     }
 
     /// Return whether the session will be keepalived for connection reuse.
@@ -4529,5 +4567,120 @@ mod test_pipelining {
         }
 
         assert!(prefix.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_within_limit() {
+        init_log();
+        let input = b"GET /hello HTTP/1.1\r\nHost: example.com\r\nX-Foo: Bar\r\n\r\n";
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(512));
+        assert_eq!(session.max_header_size(), Some(512));
+
+        let res = session.read_request().await;
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), Some(input.len()));
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_exceeded_multi_chunk() {
+        init_log();
+        // 2 chunks: total 300 bytes, limit 150
+        let chunk1 = b"GET / HTTP/1.1\r\nHost: example.com\r\nX-Custom-1: ";
+        let chunk2 = b"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz\r\n\r\n";
+        let mock_io = Builder::new().read(&chunk1[..]).read(&chunk2[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(100));
+
+        let res = session.read_request().await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_exceeded_single_chunk() {
+        init_log();
+        // Single chunk of exactly 101 bytes with limit 100:
+        // Request line (16) + Host (19) + "X-Long: " (8) + value (54) + "\r\n\r\n" (4) = 101 bytes.
+        let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nX-Long: 123456789012345678901234567890123456789012345678901234\r\n\r\n";
+        assert_eq!(input.len(), 101);
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(100));
+
+        let res = session.read_request().await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_pipelined_prefix() {
+        init_log();
+        let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nX-Header: some-long-value-that-exceeds-limit\r\n\r\n";
+        let mut prefix = BytesMut::new();
+        prefix.extend_from_slice(input);
+
+        let mock_io = Builder::new().build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(50));
+        session.set_pipelined_prefix(prefix);
+
+        let res = session.read_request().await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_headers_within_limit() {
+        init_log();
+        let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nH1: 1\r\nH2: 2\r\nH3: 3\r\n\r\n";
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_headers(Some(10));
+        assert_eq!(session.max_headers(), Some(10));
+
+        let res = session.read_request().await;
+        assert!(res.is_ok());
+        assert_eq!(session.req_header().headers.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_max_headers_exceeded() {
+        init_log();
+        // 6 headers, limit is 3
+        let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nH1: 1\r\nH2: 2\r\nH3: 3\r\nH4: 4\r\nH5: 5\r\n\r\n";
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_headers(Some(3));
+
+        let res = session.read_request().await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_limits_preserved() {
+        init_log();
+        let input = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        assert!(session.max_header_size().is_none());
+        assert!(session.max_headers().is_none());
+
+        let res = session.read_request().await;
+        assert!(res.is_ok());
     }
 }

--- a/pingora-core/src/protocols/http/v1/server.rs
+++ b/pingora-core/src/protocols/http/v1/server.rs
@@ -214,9 +214,19 @@ impl HttpSession {
         &mut self,
         buf: &mut BytesMut,
         already_read: usize,
+        max_header_size: usize,
     ) -> Result<Option<usize>> {
+        let remaining = max_header_size.saturating_sub(already_read);
+        if remaining == 0 {
+            return Error::e_explain(
+                InvalidHTTPHeader,
+                format!("Request header larger than {max_header_size}"),
+            );
+        }
+
         let read_result = {
-            let read_event = self.underlying_stream.read_buf(buf);
+            let mut limited_stream = (&mut self.underlying_stream).take(remaining as u64);
+            let read_event = limited_stream.read_buf(buf);
             match self.keepalive_timeout {
                 KeepaliveStatus::Timeout(d) => match timeout(d, read_event).await {
                     Ok(res) => res,
@@ -310,7 +320,7 @@ impl HttpSession {
         let mut skip_next_read = already_read != 0;
         let mut detached_suffix = None;
         loop {
-            if !skip_next_read && already_read > max_header_size {
+            if !skip_next_read && already_read >= max_header_size {
                 /* NOTE: this check only blocks subsequent reads. The first read is allowed
                 since the buf is already allocated or pre-filled. The goal is to avoid slowly
                 bloating this buffer when an incomplete header exceeds limits. */
@@ -328,7 +338,10 @@ impl HttpSession {
             // this request and is waiting for our response).
             if skip_next_read {
                 skip_next_read = false;
-            } else if let Some(n) = self.read_request_buf(&mut buf, already_read).await? {
+            } else if let Some(n) = self
+                .read_request_buf(&mut buf, already_read, max_header_size)
+                .await?
+            {
                 already_read += n;
             } else {
                 return Ok(None);
@@ -442,7 +455,7 @@ impl HttpSession {
                         return Ok(Some(s));
                     }
                     HeaderParseState::Partial => {
-                        if buf.len() > max_header_size {
+                        if buf.len() >= max_header_size {
                             return Error::e_explain(
                                 InvalidHTTPHeader,
                                 format!("Request header larger than {max_header_size}"),
@@ -4598,11 +4611,13 @@ mod test_pipelining {
     #[tokio::test]
     async fn test_max_header_size_exceeded_multi_chunk() {
         init_log();
-        // 2 chunks: total 300 bytes, limit 150
+        // 2 chunks: total 148 bytes, limit 100
         let chunk1 = b"GET / HTTP/1.1\r\nHost: example.com\r\nX-Custom-1: ";
         let chunk2 = b"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz\r\n\r\n";
-        let mock_io = Builder::new().read(&chunk1[..]).read(&chunk2[..]).build();
-        let mut session = HttpSession::new(Box::new(mock_io));
+        let (mut client, server) = tokio::io::duplex(1024);
+        client.write_all(&chunk1[..]).await.unwrap();
+        client.write_all(&chunk2[..]).await.unwrap();
+        let mut session = HttpSession::new(Box::new(server));
         session.set_max_header_size(Some(100)).unwrap();
 
         let res = session.read_request().await;
@@ -4620,8 +4635,9 @@ mod test_pipelining {
         // Request line (16) + Host (19) + "X-Long: " (8) + value (54) + "\r\n\r\n" (4) = 101 bytes.
         let input = b"GET / HTTP/1.1\r\nHost: example.com\r\nX-Long: 123456789012345678901234567890123456789012345678901234\r\n\r\n";
         assert_eq!(input.len(), 101);
-        let mock_io = Builder::new().read(&input[..]).build();
-        let mut session = HttpSession::new(Box::new(mock_io));
+        let (mut client, server) = tokio::io::duplex(1024);
+        client.write_all(&input[..]).await.unwrap();
+        let mut session = HttpSession::new(Box::new(server));
         session.set_max_header_size(Some(100)).unwrap();
 
         let res = session.read_request().await;
@@ -4788,5 +4804,99 @@ mod test_pipelining {
 
         let res = session.read_request().await;
         assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_exact_limit_complete_success() {
+        init_log();
+        // Construct a complete request header of exactly 100 bytes
+        let mut input = Vec::from(&b"GET / HTTP/1.1\r\nHost: a\r\nX-Pad: "[..]);
+        input.resize(96, b'a');
+        input.extend_from_slice(b"\r\n\r\n");
+        assert_eq!(input.len(), 100);
+
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(100)).unwrap();
+
+        let res = session.read_request().await;
+        assert!(res.is_ok(), "exact-limit complete header must succeed");
+        assert_eq!(res.unwrap(), Some(100));
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_exact_limit_partial_rejected_without_read() {
+        init_log();
+        // Construct an incomplete header of exactly 100 bytes (no ending CRLFCRLF)
+        let mut input = Vec::from(&b"GET / HTTP/1.1\r\nHost: a\r\nX-Pad: "[..]);
+        input.resize(100, b'a');
+        assert_eq!(input.len(), 100);
+
+        // Builder has only one read of 100 bytes. If read_request attempts another read,
+        // it would fail on mock_io. It must reject immediately on Partial at equality.
+        let mock_io = Builder::new().read(&input[..]).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(100)).unwrap();
+
+        let res = session.read_request().await;
+        assert!(
+            res.is_err(),
+            "exact-limit incomplete header must be rejected"
+        );
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_multi_read_bounded_by_remaining_budget() {
+        init_log();
+        // Test that a single read does not grow the buffer beyond the remaining budget.
+        // max_header_size = 100.
+        // Chunk 1: 90 bytes (incomplete header)
+        // Chunk 2: 50 bytes (would exceed budget if fully read into buffer)
+        let mut chunk1 = Vec::from(&b"GET / HTTP/1.1\r\nHost: a\r\nX-Pad: "[..]);
+        chunk1.resize(90, b'a');
+        assert_eq!(chunk1.len(), 90);
+
+        let chunk2 = [b'b'; 50];
+
+        let (mut client, server) = tokio::io::duplex(1024);
+        client.write_all(&chunk1).await.unwrap();
+        client.write_all(&chunk2).await.unwrap();
+        let mut session = HttpSession::new(Box::new(server));
+        session.set_max_header_size(Some(100)).unwrap();
+
+        let res = session.read_request().await;
+        assert!(res.is_err(), "multi-read exceeding budget must be rejected");
+        assert_eq!(
+            res.unwrap_err().etype(),
+            &pingora_error::ErrorType::InvalidHTTPHeader
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_header_size_multi_read_exact_limit_success() {
+        init_log();
+        // Near-limit multi-read: total 100 bytes delivered across 2 chunks of 50 bytes
+        let mut full = Vec::from(&b"GET / HTTP/1.1\r\nHost: a\r\nX-Pad: "[..]);
+        full.resize(96, b'a');
+        full.extend_from_slice(b"\r\n\r\n");
+        assert_eq!(full.len(), 100);
+
+        let chunk1 = &full[..50];
+        let chunk2 = &full[50..];
+
+        let mock_io = Builder::new().read(chunk1).read(chunk2).build();
+        let mut session = HttpSession::new(Box::new(mock_io));
+        session.set_max_header_size(Some(100)).unwrap();
+
+        let res = session.read_request().await;
+        assert!(
+            res.is_ok(),
+            "near-limit multi-read completing at exact limit must succeed"
+        );
+        assert_eq!(res.unwrap(), Some(100));
     }
 }


### PR DESCRIPTION
### Description

This PR addresses #993 by exposing configurable request-header admission limits (`max_header_size` and `max_headers`) on `HttpServerOptions`, propagating them through `ServerSession` to the underlying HTTP/1 `HttpSession`.

### Motivation

In HTTP/1.x downstream servers, Pingora previously enforced hardcoded limits:
- `MAX_HEADER_SIZE`: 1,048,575 bytes (~1 MiB)
- `MAX_HEADERS`: 256 headers

For reverse proxies and security-sensitive gateways, rejecting oversized headers only in downstream application filters (e.g. `request_filter`) is often too late: the server has already buffered up to 1 MiB of untrusted header bytes into memory per connection. Enforcing configurable admission bounds directly in `HttpSession::read_request()` prevents memory exhaustion and slowloris-style buffer bloat before request processing begins. Conversely, proxies operating in trusted environments can adjust limits appropriately.

### Key Changes

1. **`HttpServerOptions`**:
   - Added `pub max_header_size: Option<usize>` (bytes limit).
   - Added `pub max_headers: Option<usize>` (header count limit).
   - Added `validate(&self) -> Result<()>` checking that neither limit is set to `Some(0)`.

2. **Session Layer Accessors**:
   - Added `set_max_header_size`, `max_header_size`, `set_max_headers`, and `max_headers` on `ServerSession` and `HttpSession`.

3. **Zero-Allocation Parser Admission (`HttpSession::read_request`)**:
   - **Initial allocation:** Bounds initial buffer capacity to `INIT_HEADER_BUF_SIZE.min(max_header_size)`.
   - **Slow bloat guard:** Replaced hardcoded `MAX_HEADER_SIZE` guard with `already_read > max_header_size`.
   - **Count limit:** Slices the stack-allocated header array `&mut headers[..max_headers]` when constructing `httparse::Request`. This enforces the count limit on the stack with zero heap allocations, returning `InvalidHTTPHeader` via httparse's `TooManyHeaders`.
   - **Single packet guard:** Checks `if s > max_header_size` in `HeaderParseState::Complete(s)` to prevent large single-chunk reads or pipelined prefixes from exceeding limits.

4. **Keep-Alive Preservation**:
   - Propagates `server_options.max_header_size` and `server_options.max_headers` across reused connections in `HttpServerApp::process_new`.

5. **Backward Compatibility**:
   - Both settings default to `None`. When unset, existing defaults (`MAX_HEADER_SIZE = 1,048,575` bytes and `MAX_HEADERS = 256`) remain strictly intact.

### Testing

Added comprehensive unit tests covering:
- `test_max_header_size_within_limit`: Valid request within custom size limit parses successfully.
- `test_max_header_size_exceeded_multi_chunk`: Request exceeding limit across multiple chunks is rejected with `InvalidHTTPHeader`.
- `test_max_header_size_exceeded_single_chunk`: Complete request exceeding limit in a single read is rejected.
- `test_max_header_size_pipelined_prefix`: Pipelined prefix exceeding limit is rejected.
- `test_max_headers_within_limit`: Header count within custom limit succeeds.
- `test_max_headers_exceeded`: Exceeding header count limit rejects with `InvalidHTTPHeader`.
- `test_default_limits_preserved`: Default configuration preserves existing behavior.
- `test_http_server_options_validation`: Validates non-zero bounds on options.

Closes #993
