### PR TITLE
Fix KetamaHashing panic on zero-weight backend killing load balancer background task

### DIFF
--- a/pingora-load-balancing/src/selection/consistent.rs
+++ b/pingora-load-balancing/src/selection/consistent.rs
@@ -44,7 +44,13 @@ impl BackendSelection for KetamaHashing {
             .filter_map(|b| {
                 // FIXME: ketama only supports Inet addr, UDS addrs are ignored here
                 if let SocketAddr::Inet(addr) = b.addr {
-                    Some(Bucket::new(addr, b.weight as u32))
+                    // `Backend::weight` is an unvalidated usize set by whatever
+                    // `ServiceDiscovery` is in use (some treat 0 as "draining").
+                    // `Bucket::new` panics on a weight of 0, which would kill the
+                    // load balancer's background update task the next time
+                    // discovery returns such a backend. Clamp instead of passing
+                    // it through.
+                    Some(Bucket::new(addr, (b.weight as u32).max(1)))
                 } else {
                     None
                 }
@@ -156,5 +162,29 @@ mod test {
         assert_eq!(iter.next(), Some(&b1));
         let mut iter = hash.iter(b"test9");
         assert_eq!(iter.next(), Some(&b2));
+    }
+
+    #[test]
+    fn test_ketama_zero_weight_backend_does_not_panic() {
+        // A zero-weight backend used to panic inside Bucket::new and, on the
+        // real update path, take down the load balancer's background update
+        // task for good. It should be treated as weight 1 instead.
+        let b1 = Backend::new_with_weight("1.1.1.1:80", 0).unwrap();
+        let b2 = Backend::new("1.0.0.1:80").unwrap();
+        let backends = BTreeSet::from_iter([b1.clone(), b2.clone()]);
+
+        let hash = Arc::new(KetamaHashing::build(&backends));
+
+        // The zero-weight backend must still be reachable on the ring.
+        let mut seen_b1 = false;
+        for i in 0..100 {
+            let key = format!("test{i}");
+            let mut iter = hash.iter(key.as_bytes());
+            if iter.next() == Some(&b1) {
+                seen_b1 = true;
+                break;
+            }
+        }
+        assert!(seen_b1, "zero-weight backend should still get traffic");
     }
 }


### PR DESCRIPTION
Fixes #1006.

## Root cause

`KetamaHashing::build_with_config` passes `Backend::weight` (an unvalidated `usize`) straight into `pingora_ketama::Bucket::new`, which asserts `weight != 0` and panics otherwise. A `ServiceDiscovery` implementation that uses weight 0 as a draining marker, or a config/DNS typo, is enough to trigger it.

That call runs inside `LoadBalancer::update()`, called from the background update loop in `background.rs` with no `catch_unwind` or `spawn_blocking` around it. The newer `LoadBalancerGroup` rebuild path already guards the equivalent call with `spawn_blocking` and `JoinError::is_panic()`, but the plain `LoadBalancer<S>::run()` path does not. Once the panic fires, the update task ends and is never restarted: backend membership and health check state freeze permanently (or the whole process aborts, under `panic = "abort"`), from a single zero-weight entry in one discovery response.

## Fix

Clamp the weight to a minimum of 1 at the point it crosses from `Backend` into `Bucket`, in `KetamaHashing::build_with_config`. This is the only place backend weights feed into `pingora-ketama` in this crate, so it is the right boundary to treat the value as untrusted input.

## Testing

- Added `test_ketama_zero_weight_backend_does_not_panic`, which builds a `KetamaHashing` ring with a zero-weight backend and checks it is still reachable.
- Reproduced the panic on an isolated GCE VM (torn down afterward): built the parent commit with a `#[should_panic]` version of the same test and confirmed it panics with `weight must be at least one`; the fixed commit does not panic and the same test passes.
- `cargo test -p pingora-load-balancing` passes in full (79 tests) on the fixed commit.
